### PR TITLE
Implement real Hivemind network switching for #1

### DIFF
--- a/backend/src/__tests__/network-switching.integration.test.ts
+++ b/backend/src/__tests__/network-switching.integration.test.ts
@@ -1,0 +1,211 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+jest.mock('../middleware/erc8128-auth', () => ({
+  hasErc8128Headers: () => false,
+  verifyErc8128Request: jest.fn(),
+}));
+
+import dispatchRoutes from '../routes/dispatch';
+import paymentRoutes from '../routes/payments';
+import agentRoutes from '../routes/agents';
+import { registerAgent, removeAgent } from '../external-agents';
+import { callSpecialist } from '../dispatcher';
+
+const REGISTRATIONS_PATH = path.join(__dirname, '../../../agents/registrations.json');
+const EXTERNAL_AGENTS_PATH = path.join(__dirname, '../../data/external-agents.json');
+const SIMULATED_BALANCES_PATH = path.join(__dirname, '../../data/simulated-balances.json');
+
+describe('environment switching integration', () => {
+  let registrationsBackup = '';
+  let externalAgentsBackup: string | null = null;
+  let simulatedBalancesBackup: string | null = null;
+
+  beforeAll(async () => {
+    process.env.ENABLE_MAINNET_DISPATCH = 'true';
+
+    registrationsBackup = fs.readFileSync(REGISTRATIONS_PATH, 'utf8');
+    externalAgentsBackup = fs.existsSync(EXTERNAL_AGENTS_PATH) ? fs.readFileSync(EXTERNAL_AGENTS_PATH, 'utf8') : null;
+    simulatedBalancesBackup = fs.existsSync(SIMULATED_BALANCES_PATH) ? fs.readFileSync(SIMULATED_BALANCES_PATH, 'utf8') : null;
+  });
+
+  afterAll(async () => {
+    removeAgent('network-switch-auditor', 'testnet');
+    removeAgent('network-switch-auditor', 'mainnet');
+
+    fs.writeFileSync(REGISTRATIONS_PATH, registrationsBackup, 'utf8');
+
+    if (externalAgentsBackup === null) {
+      fs.rmSync(EXTERNAL_AGENTS_PATH, { force: true });
+    } else {
+      fs.writeFileSync(EXTERNAL_AGENTS_PATH, externalAgentsBackup, 'utf8');
+    }
+
+    if (simulatedBalancesBackup === null) {
+      fs.rmSync(SIMULATED_BALANCES_PATH, { force: true });
+    } else {
+      fs.writeFileSync(SIMULATED_BALANCES_PATH, simulatedBalancesBackup, 'utf8');
+    }
+  });
+
+  function getRouteHandler(router: any, method: 'get' | 'post', routePath: string) {
+    const layer = router.stack.find((entry: any) => entry.route?.path === routePath && entry.route.methods?.[method]);
+    if (!layer) {
+      throw new Error(`Route ${method.toUpperCase()} ${routePath} not found`);
+    }
+    return layer.route.stack[layer.route.stack.length - 1].handle;
+  }
+
+  async function invokeRoute(
+    router: any,
+    method: 'get' | 'post',
+    routePath: string,
+    options: { body?: any; query?: any; params?: any; headers?: Record<string, string> } = {}
+  ) {
+    const handler = getRouteHandler(router, method, routePath);
+    const req: any = {
+      body: options.body || {},
+      query: options.query || {},
+      params: options.params || {},
+      headers: options.headers || {},
+      header(name: string) {
+        return this.headers[name] || this.headers[name.toLowerCase()];
+      },
+      get(name: string) {
+        return this.header(name);
+      },
+      path: routePath,
+      method: method.toUpperCase(),
+      originalUrl: routePath,
+    };
+
+    return await new Promise<{ status: number; json: any }>((resolve, reject) => {
+      const res: any = {
+        statusCode: 200,
+        status(code: number) {
+          this.statusCode = code;
+          return this;
+        },
+        json(payload: any) {
+          resolve({ status: this.statusCode, json: payload });
+          return this;
+        },
+      };
+
+      Promise.resolve(handler(req, res, reject)).catch(reject);
+    });
+  }
+
+  it('switches route preview and wallet metadata between testnet and mainnet', async () => {
+    const [testnetPreview, mainnetPreview] = await Promise.all([
+      invokeRoute(dispatchRoutes, 'post', '/route-preview', { body: { prompt: 'check my wallet balance', networkMode: 'testnet' } }),
+      invokeRoute(dispatchRoutes, 'post', '/route-preview', { body: { prompt: 'check my wallet balance', networkMode: 'mainnet' } }),
+    ]);
+
+    expect(testnetPreview.status).toBe(200);
+    expect(mainnetPreview.status).toBe(200);
+    expect(testnetPreview.json.networkMode).toBe('testnet');
+    expect(mainnetPreview.json.networkMode).toBe('mainnet');
+    expect(testnetPreview.json.network).toBe('base-sepolia');
+    expect(mainnetPreview.json.network).toBe('base-mainnet');
+    expect(testnetPreview.json.chainId).toBe(84532);
+    expect(mainnetPreview.json.chainId).toBe(8453);
+    expect(testnetPreview.json.usdcAddress).toBe('0x036CbD53842c5426634e7929541eC2318f3dCF7e');
+    expect(mainnetPreview.json.usdcAddress).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+
+    const [testnetBalances, mainnetBalances] = await Promise.all([
+      invokeRoute(paymentRoutes, 'get', '/wallet/balances', { query: { network: 'testnet' } }),
+      invokeRoute(paymentRoutes, 'get', '/wallet/balances', { query: { network: 'mainnet' } }),
+    ]);
+
+    expect(testnetBalances.status).toBe(200);
+    expect(mainnetBalances.status).toBe(200);
+    expect(testnetBalances.json.chain).toBe('base-sepolia');
+    expect(mainnetBalances.json.chain).toBe('base-mainnet');
+    expect(testnetBalances.json.chainId).toBe(84532);
+    expect(mainnetBalances.json.chainId).toBe(8453);
+    expect(testnetBalances.json.usdcAddress).toBe('0x036CbD53842c5426634e7929541eC2318f3dCF7e');
+    expect(mainnetBalances.json.usdcAddress).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+  });
+
+  it('keeps external agents isolated per network when the same agent name exists on both chains', async () => {
+    registerAgent({
+      name: 'Network Switch Auditor',
+      description: 'Security auditor on testnet',
+      endpoint: 'https://testnet.example.com',
+      wallet: '0x1111111111111111111111111111111111111111',
+      capabilities: ['security-audit'],
+      pricing: { generic: 0.25 },
+      chain: 'eip155:84532',
+    });
+
+    registerAgent({
+      name: 'Network Switch Auditor',
+      description: 'Security auditor on mainnet',
+      endpoint: 'https://mainnet.example.com',
+      wallet: '0x2222222222222222222222222222222222222222',
+      capabilities: ['security-audit'],
+      pricing: { generic: 0.95 },
+      chain: 'eip155:8453',
+    });
+
+    const [testnetAgents, mainnetAgents, testnetRegistry, mainnetRegistry] = await Promise.all([
+      invokeRoute(agentRoutes, 'get', '/agents/external', { query: { network: 'testnet' } }),
+      invokeRoute(agentRoutes, 'get', '/agents/external', { query: { network: 'mainnet' } }),
+      invokeRoute(agentRoutes, 'get', '/agents', { query: { network: 'testnet' } }),
+      invokeRoute(agentRoutes, 'get', '/agents', { query: { network: 'mainnet' } }),
+    ]);
+
+    expect(testnetAgents.status).toBe(200);
+    expect(mainnetAgents.status).toBe(200);
+    expect(testnetAgents.json.count).toBeGreaterThanOrEqual(1);
+    expect(mainnetAgents.json.count).toBeGreaterThanOrEqual(1);
+
+    const testnetAgent = testnetAgents.json.agents.find((agent: any) => agent.name === 'Network Switch Auditor');
+    const mainnetAgent = mainnetAgents.json.agents.find((agent: any) => agent.name === 'Network Switch Auditor');
+
+    expect(testnetAgent).toBeTruthy();
+    expect(mainnetAgent).toBeTruthy();
+    expect(testnetAgent.endpoint).toBe('https://testnet.example.com');
+    expect(mainnetAgent.endpoint).toBe('https://mainnet.example.com');
+    expect(testnetAgent.wallet).toBe('0x1111111111111111111111111111111111111111');
+    expect(mainnetAgent.wallet).toBe('0x2222222222222222222222222222222222222222');
+    expect(testnetAgent.chain).toBe('base-sepolia');
+    expect(mainnetAgent.chain).toBe('base-mainnet');
+
+    expect(testnetRegistry.json.networkMode).toBe('testnet');
+    expect(mainnetRegistry.json.networkMode).toBe('mainnet');
+    expect(testnetRegistry.json.chainId).toBe(84532);
+    expect(mainnetRegistry.json.chainId).toBe(8453);
+  });
+
+  it('switches bankr wallet-action payloads to the active base network', async () => {
+    fs.writeFileSync(
+      SIMULATED_BALANCES_PATH,
+      JSON.stringify({
+        lastRealBalanceCheck: Date.now(),
+        realSOL: 10,
+        balances: { SOL: 10, USDC: 250 },
+        transactions: [],
+      }, null, 2),
+      'utf8'
+    );
+
+    const prompt = 'send 5 usdc to 0x1234567890123456789012345678901234567890';
+    const [testnetResult, mainnetResult] = await Promise.all([
+      callSpecialist('bankr', prompt, { metadata: { networkMode: 'testnet' } }),
+      callSpecialist('bankr', prompt, { metadata: { networkMode: 'mainnet' } }),
+    ]);
+
+    expect(testnetResult.success).toBe(true);
+    expect(mainnetResult.success).toBe(true);
+    expect(testnetResult.data.details.network).toBe('base-sepolia');
+    expect(mainnetResult.data.details.network).toBe('base-mainnet');
+    expect(testnetResult.data.details.chainId).toBe(84532);
+    expect(mainnetResult.data.details.chainId).toBe(8453);
+    expect(testnetResult.data.details.usdcContract).toBe('0x036CbD53842c5426634e7929541eC2318f3dCF7e');
+    expect(mainnetResult.data.details.usdcContract).toBe('0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(String(testnetResult.data.summary)).toContain('Base Sepolia');
+    expect(String(mainnetResult.data.summary)).toContain('Base Mainnet');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,8 @@ import reputationRoutes from './routes/reputation';
 import generalRoutes from './routes/general';
 import bazaarRoutes from './routes/bazaar';
 import { createX402Middleware } from './x402-server';
+import { normalizeClientNetworkMode } from './utils/client-network';
+import { getNetworkConfig } from './utils/network-config';
 
 dotenv.config();
 
@@ -116,14 +118,17 @@ app.get('/status/:taskId', (req, res, next) => {
 });
 
 // Status (authenticated, includes treasury balance)
-app.get('/status', async (_req: Request, res: Response) => {
+app.get('/status', async (req: Request, res: Response) => {
   try {
+    const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+    const network = getNetworkConfig(mode);
     const { getTreasuryBalance } = require('./payments');
-    const balances = await getTreasuryBalance();
+    const balances = await getTreasuryBalance(mode);
     res.json({
       status: 'ok',
-      treasury: { address: '0x676fF3d546932dE6558a267887E58e39f405B135', balances },
-      chain: 'Base Sepolia (EIP-155:84532)',
+      treasury: { address: network.treasuryAddress, balances },
+      chain: network.displayName,
+      networkMode: mode,
       specialists: ['magos', 'aura', 'bankr', 'seeker', 'scribe'],
       uptime: process.uptime(),
     });

--- a/backend/src/bazaar.ts
+++ b/backend/src/bazaar.ts
@@ -58,6 +58,12 @@ export interface DiscoveredAgent {
   };
 }
 
+function getPricingCacheKey(agent: DiscoveredAgent): string | null {
+  const endpoint = getAgentEndpoint(agent);
+  if (!endpoint) return null;
+  return `${agent.chainId}:${endpoint}`;
+}
+
 /**
  * Discover external agents from 8004scan's ERC-8004 registry.
  * Uses the leaderboard endpoint for quality-ranked results.
@@ -95,7 +101,8 @@ export async function discoverAgents(options?: {
       const agents = (data.items || [])
         .filter((a: any) => a.x402_supported && a.name && !/^Agent #\d+$/.test(a.name))
         .map((a: any) => mapAgent(a));
-      return { agents, total: data.total || agents.length };
+      const filtered = agents.filter((agent) => network === 'all' || (network === 'mainnet' ? !agent.isTestnet : agent.isTestnet));
+      return { agents: filtered.map((agent) => enrichWithPricing(agent)), total: filtered.length };
     }
 
     // Leaderboard mode — fetch mainnet and/or testnet
@@ -237,10 +244,9 @@ function mapAgent(a: any): DiscoveredAgent {
  * Enrich an agent with cached pricing data.
  */
 function enrichWithPricing(agent: DiscoveredAgent): DiscoveredAgent {
-  const endpoint = getAgentEndpoint(agent);
-  if (!endpoint) return agent;
-
-  const cached = pricingCache.get(endpoint);
+  const cacheKey = getPricingCacheKey(agent);
+  if (!cacheKey) return agent;
+  const cached = pricingCache.get(cacheKey);
   if (cached && Date.now() - cached.timestamp < PRICING_CACHE_TTL) {
     return { ...agent, pricing: { amount: cached.amount, network: cached.network, payTo: cached.payTo } };
   }
@@ -264,9 +270,9 @@ function getAgentEndpoint(agent: DiscoveredAgent): string | null {
  */
 async function backgroundProbeAll(agents: DiscoveredAgent[]): Promise<void> {
   const toProbe = agents.filter(a => {
-    const ep = getAgentEndpoint(a);
-    if (!ep) return false;
-    const cached = pricingCache.get(ep);
+    const cacheKey = getPricingCacheKey(a);
+    if (!cacheKey) return false;
+    const cached = pricingCache.get(cacheKey);
     return !cached || Date.now() - cached.timestamp >= PRICING_CACHE_TTL;
   });
 
@@ -280,10 +286,11 @@ async function backgroundProbeAll(agents: DiscoveredAgent[]): Promise<void> {
     await Promise.allSettled(
       batch.map(async (agent) => {
         const ep = getAgentEndpoint(agent);
+        const cacheKey = getPricingCacheKey(agent);
         if (!ep) return;
         const pricing = await probeAgentPricing(ep);
-        if (pricing) {
-          pricingCache.set(ep, { ...pricing, timestamp: Date.now() });
+        if (pricing && cacheKey) {
+          pricingCache.set(cacheKey, { ...pricing, timestamp: Date.now() });
           console.log(`[Discovery] Pricing: ${agent.name} = $${pricing.amount} USDC`);
         }
       })

--- a/backend/src/capability-matcher.ts
+++ b/backend/src/capability-matcher.ts
@@ -11,6 +11,7 @@ import { getReputationScore, getReputationStats } from './reputation';
 import { priceRouter } from './price-router';
 import { config } from './config';
 import { chatJSON, MODELS } from './llm-client';
+import type { ClientNetworkMode } from './utils/client-network';
 
 const DATA_DIR = path.join(__dirname, '../data');
 const EMBEDDINGS_FILE = path.join(DATA_DIR, 'embeddings.json');
@@ -230,7 +231,7 @@ Example: "Audit this contract 0x123... on Base"
   /**
    * Match agents against user intent
    */
-  async matchAgents(intent: UserIntent): Promise<RankedAgent[]> {
+  async matchAgents(intent: UserIntent, networkMode: ClientNetworkMode = 'testnet'): Promise<RankedAgent[]> {
     const queryText = intent.requiredCapabilities.join(' ') + ' ' + intent.category;
     const queryVector = await this.embeddingService.generateEmbedding(queryText);
 
@@ -238,7 +239,7 @@ Example: "Audit this contract 0x123... on Base"
 
     // 1. Get all agents (built-in + external)
     const builtInAgents = Array.from(this.specialistManifests.keys());
-    const externalAgents = getExternalAgents();
+    const externalAgents = getExternalAgents(networkMode);
 
     const allAgents = [
       ...builtInAgents.map(id => ({ id, capabilities: this.specialistManifests.get(id) || [] })),

--- a/backend/src/dispatcher.ts
+++ b/backend/src/dispatcher.ts
@@ -40,6 +40,8 @@ import { processingIdempotencyStore } from './reliability/idempotency-store';
 import { withRetry, isTransientError } from './reliability/retry';
 import { getReliabilityConfig } from './reliability/config';
 import { enqueueDlq } from './reliability/dlq';
+import { getNetworkConfig } from './utils/network-config';
+import type { ClientNetworkMode } from './utils/client-network';
 
 // Persistence settings
 const DATA_DIR = path.join(__dirname, '../data');
@@ -122,14 +124,18 @@ const SPECIALIST_DESCRIPTIONS: Record<SpecialistType, string> = {
  * Resolve fee for a specialist (internal or external)
  * Internal specialists use config.fees, external agents use their registered pricing
  */
-function resolveAgentFee(specialistId: string, taskType?: string): number {
+function resolveAgentFee(
+  specialistId: string,
+  taskType?: string,
+  networkMode: ClientNetworkMode = 'testnet'
+): number {
   // Check internal fees first
   const internalFee = (config.fees as any)[specialistId];
   if (internalFee !== undefined) return internalFee;
   
   // Check external agent pricing
   if (isExternalAgent(specialistId)) {
-    const agent = getExternalAgent(specialistId);
+    const agent = getExternalAgent(specialistId, networkMode);
     if (agent?.pricing) {
       // Try task-specific price, then generic, then first available
       return agent.pricing[taskType || ''] || agent.pricing['security-audit'] || agent.pricing['generic'] || Object.values(agent.pricing)[0] || 0;
@@ -268,6 +274,8 @@ function addMessage(task: Task, from: string, to: string, content: string): void
  */
 export async function dispatch(request: DispatchRequest): Promise<DispatchResponse> {
   const taskId = uuidv4();
+  const networkMode = resolveTaskNetworkMode(request.networkMode);
+  const network = getNetworkConfig(networkMode);
   
   // Pre-check: Security audit fast-path BEFORE complexity detection
   // "audit contract" often triggers false positive complexity (security + wallet domains)
@@ -297,7 +305,7 @@ export async function dispatch(request: DispatchRequest): Promise<DispatchRespon
   
   // Determine the best specialist for this prompt
   // If >1 step, it's multi-hop. If 1 step, use existing routing logic (Capability/RegExp/etc)
-  let bestSpecialist = request.preferredSpecialist || (isMultiStep ? 'multi-hop' as SpecialistType : await routePrompt(request.prompt, request.hiredAgents));
+  let bestSpecialist = request.preferredSpecialist || (isMultiStep ? 'multi-hop' as SpecialistType : await routePrompt(request.prompt, request.hiredAgents, networkMode));
   
   // Legacy multi-hop detection — check before building fallback chains
   // Skip for sentinel queries (audit prompts trigger false positives in multi-domain detection)
@@ -320,7 +328,7 @@ export async function dispatch(request: DispatchRequest): Promise<DispatchRespon
       taskFallbackChain = [bestSpecialist, 'scribe']; // Simple fallback to scribe
     } else {
       try {
-        const chain = await fallbackChain.buildFallbackChain(request.prompt, []);
+        const chain = await fallbackChain.buildFallbackChain(request.prompt, [], networkMode);
         taskFallbackChain = chain.map(c => c.agentId);
         if (taskFallbackChain.length > 0 && taskFallbackChain[0] !== bestSpecialist && taskFallbackChain.includes(bestSpecialist)) {
           taskFallbackChain = [bestSpecialist, ...taskFallbackChain.filter(id => id !== bestSpecialist)];
@@ -338,7 +346,7 @@ export async function dispatch(request: DispatchRequest): Promise<DispatchRespon
   if (request.maxBudget !== undefined) {
     const budgetCheck = priceRouter.checkBudget(dagPlan, request.maxBudget);
     // For single-step, ensure we also check the bestSpecialist fee if it's different from the plan
-    const singleStepFee = !isMultiStep ? resolveAgentFee(bestSpecialist) : 0;
+    const singleStepFee = !isMultiStep ? resolveAgentFee(bestSpecialist, undefined, networkMode) : 0;
     const finalEstimatedCost = Math.max(budgetCheck.totalCost, singleStepFee);
     
     if (finalEstimatedCost > request.maxBudget) {
@@ -380,7 +388,7 @@ export async function dispatch(request: DispatchRequest): Promise<DispatchRespon
     
     // For external agents, get pricing from their registration
     if (!pricing && isExternalAgent(bestSpecialist)) {
-      const extAgent = getExternalAgent(bestSpecialist);
+      const extAgent = getExternalAgent(bestSpecialist, networkMode);
       const extFee = extAgent?.pricing?.['security-audit'] || extAgent?.pricing?.['generic'] || Object.values(extAgent?.pricing || {})[0] || 0;
       pricing = { fee: String(extFee), description: extAgent?.description || 'External agent' };
     }
@@ -430,7 +438,9 @@ export async function dispatch(request: DispatchRequest): Promise<DispatchRespon
       hops: finalHops || undefined,
       hiredAgents: request.hiredAgents,
       wasApproved: isApproved,
-      intent: (bestSpecialist as any).intent || undefined
+      intent: (bestSpecialist as any).intent || undefined,
+      networkMode,
+      routeNetwork: network.routeLabel,
     },
     dagPlan, // Store the DAG plan for execution
     fallbackChain: taskFallbackChain, // Added for Phase 2e
@@ -478,6 +488,8 @@ function getSpecialistDisplayName(specialist: SpecialistType): string {
 export async function executeTask(task: Task, dryRun: boolean, paymentProof?: string): Promise<void> {
   const processingKey = `task:${task.id}:execute`;
   const processingFingerprint = `${task.id}:${task.updatedAt.toISOString()}`;
+  const networkMode = resolveTaskNetworkMode(task.metadata?.networkMode);
+  const network = getNetworkConfig(networkMode);
   const processingReservation = processingIdempotencyStore.reserve(processingKey, processingFingerprint, task.id);
   if (processingReservation.duplicate && processingReservation.record.status === 'in_progress') {
     console.log(`[Dispatcher] Skipping duplicate executeTask for ${task.id} (already in progress)`);
@@ -503,7 +515,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
       addMessage(task, 'dispatcher', step.specialist, `[Step ${step.id}] Routing to ${step.specialist}...`);
       
       // 3. Call the specialist (gated)
-      const result = await callSpecialistGated(step.specialist, resolvedPrompt);
+      const result = await callSpecialistGated(step.specialist, resolvedPrompt, task);
       
       // 4. Specialist response message
       const responseContent = extractResponseContent(result);
@@ -513,7 +525,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
       const fee = step.estimatedCost || (config.fees as any)[step.specialist] || 0;
       if (fee > 0 && !dryRun && !paymentProof) {
         // Log the fee for this step — actual payment handled by delegation or x402 protocol
-        const feeRecord = createPaymentRecord(String(fee), 'USDC', 'base-sepolia', step.specialist, undefined, 'pending');
+        const feeRecord = createPaymentRecord(String(fee), 'USDC', network.routeLabel, step.specialist, undefined, 'pending');
         task.payments.push(feeRecord);
         logTransaction(feeRecord);
         addMessage(task, 'x402', 'dispatcher', `💰 Fee: ${fee} USDC → ${step.specialist}`);
@@ -565,7 +577,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
         cost: {
           amount: String(dagResult.totalCost || task.dagPlan?.totalEstimatedCost || 0),
           currency: 'USDC',
-          network: 'base',
+          network: network.routeLabel,
           recipient: 'multi-agent-workflow',
         },
       };
@@ -603,7 +615,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
       addMessage(task, 'dispatcher', specialist, `[Step ${step}/${hops.length}] Routing to ${specialist}...`);
       
       // Call the specialist via x402-gated endpoint
-      const result = await callSpecialistGated(specialist, currentContext);
+      const result = await callSpecialistGated(specialist, currentContext, task);
       multiResults.push({ specialist, result });
       
       // Add specialist response message
@@ -613,7 +625,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
       // Execute x402 payment for this hop (primary), on-chain fallback
       const specialistFee = (config.fees as any)[specialist] || 0;
       if (specialistFee > 0 && !dryRun && !paymentProof) {
-        const feeRecord = createPaymentRecord(String(specialistFee), 'USDC', 'base-sepolia', specialist, undefined, 'pending');
+        const feeRecord = createPaymentRecord(String(specialistFee), 'USDC', network.routeLabel, specialist, undefined, 'pending');
         task.payments.push(feeRecord);
         logTransaction(feeRecord);
         addMessage(task, 'x402', 'dispatcher', `💰 Fee: ${specialistFee} USDC → ${specialist}`);
@@ -680,11 +692,11 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
     addMessage(task, 'dispatcher', task.specialist, 'Checking x402 payment...');
     
     // Check balance
-    const balances = await getTreasuryBalance();
+    const balances = await getTreasuryBalance(networkMode);
     console.log(`[Dispatcher] Treasury balance:`, balances);
     
     // Enforce payment if config flag is set
-    const fee = resolveAgentFee(task.specialist);
+    const fee = resolveAgentFee(task.specialist, undefined, networkMode);
     const usdcBalance = balances.usdc;
 
     if (config.enforcePayments && usdcBalance < fee) {
@@ -697,7 +709,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
   updateTaskStatus(task, 'processing');
   
   // Get specialist fee (internal or external)
-  const fee = resolveAgentFee(task.specialist);
+  const fee = resolveAgentFee(task.specialist, undefined, networkMode);
   addMessage(task, 'dispatcher', task.specialist, `Processing with ${task.specialist}... (fee: ${fee} USDC)`);
   
   // Call the specialist via x402-gated endpoint
@@ -761,7 +773,7 @@ export async function executeTask(task: Task, dryRun: boolean, paymentProof?: st
   if (fee > 0 && !dryRun && !paymentProof) {
     addMessage(task, 'x402', 'dispatcher', `⏳ Processing ${fee} USDC payment via x402...`);
     
-    const feeRecord = createPaymentRecord(String(fee), 'USDC', 'base-sepolia', task.specialist, undefined, 'pending');
+    const feeRecord = createPaymentRecord(String(fee), 'USDC', network.routeLabel, task.specialist, undefined, 'pending');
     task.payments.push(feeRecord);
     logTransaction(feeRecord);
     addMessage(task, 'x402', 'dispatcher', `💰 Fee: ${fee} USDC → ${task.specialist}`);
@@ -1017,10 +1029,14 @@ export function updateTaskStatus(task: Task, status: TaskStatus, extra?: Record<
  * Supports Capability-based (modern), LLM-based (smart) and RegExp-based (fast) routing
  * Only routes to specialists in the hiredAgents list if provided
  */
-function buildRouteCacheKey(prompt: string, hiredAgents?: SpecialistType[]): string {
+function resolveTaskNetworkMode(input?: unknown): ClientNetworkMode {
+  return input === 'mainnet' ? 'mainnet' : 'testnet';
+}
+
+function buildRouteCacheKey(prompt: string, hiredAgents?: SpecialistType[], networkMode: ClientNetworkMode = 'testnet'): string {
   const normalizedPrompt = prompt.trim().toLowerCase();
   const swarm = (hiredAgents || []).slice().sort().join(',');
-  return `${normalizedPrompt}::${swarm}`;
+  return `${networkMode}::${normalizedPrompt}::${swarm}`;
 }
 
 function setRouteCache(key: string, specialist: SpecialistType): void {
@@ -1031,10 +1047,14 @@ function setRouteCache(key: string, specialist: SpecialistType): void {
   routeCache.set(key, { specialist, expiresAt: Date.now() + ROUTE_CACHE_TTL_MS });
 }
 
-export async function routePrompt(prompt: string, hiredAgents?: SpecialistType[]): Promise<SpecialistType> {
+export async function routePrompt(
+  prompt: string,
+  hiredAgents?: SpecialistType[],
+  networkMode: ClientNetworkMode = 'testnet'
+): Promise<SpecialistType> {
   const lower = prompt.toLowerCase();
   const planningMode = process.env.PLANNING_MODE || 'capability';
-  const cacheKey = buildRouteCacheKey(prompt, hiredAgents);
+  const cacheKey = buildRouteCacheKey(prompt, hiredAgents, networkMode);
   const cached = routeCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return cached.specialist;
@@ -1137,7 +1157,7 @@ export async function routePrompt(prompt: string, hiredAgents?: SpecialistType[]
     console.log(`[Router] Fast-path: contract audit query detected, looking for security specialist`);
     
     // Find external agent with security capability
-    const agents = getExternalAgents();
+    const agents = getExternalAgents(networkMode);
     const securityAgent = agents.find(a => 
       a.capabilities?.some((c: string) => {
         const normalized = c.toLowerCase().replace(/\s+/g, '-');
@@ -1418,11 +1438,13 @@ export async function callSpecialistGated(specialistId: string, prompt: string, 
  */
 export async function callSpecialist(specialist: SpecialistType, prompt: string, context?: any): Promise<SpecialistResult> {
   const startTime = Date.now();
+  const networkMode = resolveTaskNetworkMode(context?.metadata?.networkMode);
+  const network = getNetworkConfig(networkMode);
   
   // Check if this is an external agent (registered via marketplace)
-  if (isExternalAgent(specialist as string)) {
+  if (getExternalAgent(specialist as string, networkMode)) {
     console.log(`[Dispatcher] Routing to external agent: ${specialist}`);
-    const externalResult = await callExternalAgent(specialist as string, prompt);
+    const externalResult = await callExternalAgent(specialist as string, prompt, undefined, networkMode);
     
     // Fallback to best internal specialist if external agent fails (timeout, unhealthy, etc.)
     if (!externalResult.success && !externalResult.cost) {
@@ -1491,7 +1513,7 @@ export async function callSpecialist(specialist: SpecialistType, prompt: string,
       result.cost = {
         amount: String(fee),
         currency: 'USDC',
-        network: 'base',
+        network: network.routeLabel,
         recipient: config.specialistWallets[specialist] || 'treasury',
       };
     }
@@ -1559,7 +1581,7 @@ export function getSpecialists(): any[] {
   });
   
   // External agents from the registry
-  const external = getExternalAgents()
+  const external = getExternalAgents('testnet')
     .filter(a => a.active && a.healthy)
     .map(a => ({
       name: a.id,

--- a/backend/src/external-agents.ts
+++ b/backend/src/external-agents.ts
@@ -6,12 +6,12 @@
  */
 
 import { privateKeyToAccount } from 'viem/accounts';
-import { baseSepolia } from 'viem/chains';
 import * as fs from 'fs';
 import * as path from 'path';
-import { v4 as uuidv4 } from 'uuid';
 import { SpecialistResult, Capability, ExternalAgent, RegisterRequest } from './types';
 import { parsePaymentRequiredHeader } from './utils/payment-required';
+import { getNetworkConfig, getNetworkModeFromChain, isAgentOnNetwork } from './utils/network-config';
+import type { ClientNetworkMode } from './utils/client-network';
 
 // Lazy-load x402/erc8128 deps so Jest (CJS) doesn't choke on ESM-only packages.
 let createSignerClient: any = null;
@@ -36,34 +36,38 @@ const EXTERNAL_AGENTS_FILE = path.join(DATA_DIR, 'external-agents.json');
 
 // ── ERC-8128 Signer (for outgoing requests) ───────────────────────────
 const privateKey = process.env.DEMO_WALLET_PRIVATE_KEY;
-let signerClient: any = null;
-let signerAddress: string | null = null;
+const signerClients = new Map<ClientNetworkMode, any>();
+const x402HttpClients = new Map<ClientNetworkMode, any>();
 
-if (privateKey) {
+function getSignerClient(mode: ClientNetworkMode): any | null {
+  if (!privateKey) return null;
+  if (signerClients.has(mode)) return signerClients.get(mode);
   try {
     loadPaymentDeps();
     const account = privateKeyToAccount(privateKey as `0x${string}`);
     if (!createSignerClient) {
       throw new Error('erc8128 module not loaded');
     }
-    signerAddress = account.address;
-    signerClient = createSignerClient({
-      chainId: baseSepolia.id,
+    const network = getNetworkConfig(mode);
+    const client = createSignerClient({
+      chainId: network.chainId,
       address: account.address,
       signMessage: async (message: any) => {
         return await account.signMessage({ message: { raw: message } });
       },
     });
-    console.log(`[ExternalAgents] ERC-8128 signer ready: ${account.address}`);
+    signerClients.set(mode, client);
+    console.log(`[ExternalAgents] ERC-8128 signer ready for ${mode}: ${account.address}`);
+    return client;
   } catch (err) {
-    console.error('[ExternalAgents] Failed to init ERC-8128 signer:', err);
+    console.error(`[ExternalAgents] Failed to init ERC-8128 signer for ${mode}:`, err);
+    return null;
   }
 }
 
-// ── x402 Payment Client (for paying external agents) ──────────────────
-let x402HttpClient: any = null;
-
-if (privateKey) {
+function getX402HttpClient(mode: ClientNetworkMode): any | null {
+  if (!privateKey) return null;
+  if (x402HttpClients.has(mode)) return x402HttpClients.get(mode);
   try {
     loadPaymentDeps();
     const account = privateKeyToAccount(privateKey as `0x${string}`);
@@ -72,15 +76,26 @@ if (privateKey) {
     }
     const client = new x402Client();
     registerExactEvmScheme(client, { signer: account });
-    x402HttpClient = new x402HTTPClient(client);
-    console.log(`[ExternalAgents] x402 payment client ready: ${account.address}`);
+    const httpClient = new x402HTTPClient(client);
+    x402HttpClients.set(mode, httpClient);
+    console.log(`[ExternalAgents] x402 payment client ready for ${mode}: ${account.address}`);
+    return httpClient;
   } catch (err) {
-    console.error('[ExternalAgents] Failed to init x402 client:', err);
+    console.error(`[ExternalAgents] Failed to init x402 client for ${mode}:`, err);
+    return null;
   }
 }
 
 // In-memory store, persisted to disk
 let externalAgents: Map<string, ExternalAgent> = new Map();
+
+function normalizeAgentChain(chain?: string): string {
+  return getNetworkConfig(getNetworkModeFromChain(chain)).routeLabel;
+}
+
+function getExternalAgentStorageKey(id: string, chain: string): string {
+  return `${id}::${normalizeAgentChain(chain)}`;
+}
 
 /**
  * Load external agents from disk
@@ -107,7 +122,8 @@ function loadAgents(): void {
             latencyEstimateMs: 1000,
           }));
         }
-        externalAgents.set(agent.id, agent);
+        agent.chain = normalizeAgentChain(agent.chain);
+        externalAgents.set(getExternalAgentStorageKey(agent.id, agent.chain), agent);
       }
       console.log(`[ExternalAgents] Loaded ${externalAgents.size} external agents`);
     }
@@ -140,6 +156,8 @@ loadAgents();
 export function registerAgent(req: RegisterRequest): ExternalAgent {
   // Generate a slug-style ID from the name
   const id = req.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const normalizedChain = normalizeAgentChain(req.chain);
+  const storageKey = getExternalAgentStorageKey(id, normalizedChain);
   
   // Ensure structured capabilities exist (backward compatibility)
   const structuredCapabilities = req.structuredCapabilities || req.capabilities.map(cap => ({
@@ -155,19 +173,19 @@ export function registerAgent(req: RegisterRequest): ExternalAgent {
   }));
 
   // Check if already registered
-  if (externalAgents.has(id)) {
+  if (externalAgents.has(storageKey)) {
     // Update existing registration
-    const existing = externalAgents.get(id)!;
+    const existing = externalAgents.get(storageKey)!;
     existing.description = req.description;
     existing.endpoint = req.endpoint;
     existing.wallet = req.wallet;
     existing.capabilities = req.capabilities;
     existing.structuredCapabilities = structuredCapabilities;
     existing.pricing = req.pricing || {};
-    existing.chain = req.chain || 'base-sepolia';
+    existing.chain = normalizedChain;
     existing.active = true;
     saveAgents();
-    console.log(`[ExternalAgents] Updated registration: ${id}`);
+    console.log(`[ExternalAgents] Updated registration: ${storageKey}`);
     return existing;
   }
 
@@ -180,7 +198,7 @@ export function registerAgent(req: RegisterRequest): ExternalAgent {
     capabilities: req.capabilities,
     structuredCapabilities,
     pricing: req.pricing || {},
-    chain: req.chain || 'base-sepolia',
+    chain: normalizedChain,
     x402Support: true,
     erc8128Support: req.erc8128Support || false,
     erc8004: { registered: true },
@@ -189,7 +207,7 @@ export function registerAgent(req: RegisterRequest): ExternalAgent {
     active: true,
   };
 
-  externalAgents.set(id, agent);
+  externalAgents.set(storageKey, agent);
   saveAgents();
 
   // Trigger embedding sync (non-blocking)
@@ -202,7 +220,7 @@ export function registerAgent(req: RegisterRequest): ExternalAgent {
   // Also update the registrations.json for the /api/agents endpoint
   updateRegistrationsJson(agent);
 
-  console.log(`[ExternalAgents] Registered new agent: ${id} -> ${agent.endpoint}`);
+  console.log(`[ExternalAgents] Registered new agent: ${storageKey} -> ${agent.endpoint}`);
   return agent;
 }
 
@@ -215,7 +233,7 @@ function updateRegistrationsJson(agent: ExternalAgent): void {
     const registrations = JSON.parse(fs.readFileSync(regFile, 'utf8'));
     
     // Check if agent already exists in registrations
-    const existingIdx = registrations.findIndex((r: any) => r.name === agent.name);
+    const existingIdx = registrations.findIndex((r: any) => r.name === agent.name && normalizeAgentChain(r.chain || r.networkMode) === agent.chain);
     
     const registration = {
       type: "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
@@ -238,6 +256,8 @@ function updateRegistrationsJson(agent: ExternalAgent): void {
       registrations: [],
       supportedTrust: ["reputation"],
       external: true, // Mark as externally registered
+      chain: agent.chain,
+      networkMode: getNetworkModeFromChain(agent.chain),
       wallet: agent.wallet,
       capabilities: agent.capabilities,
       pricing: agent.pricing,
@@ -259,22 +279,33 @@ function updateRegistrationsJson(agent: ExternalAgent): void {
 /**
  * Get all external agents
  */
-export function getExternalAgents(): ExternalAgent[] {
-  return Array.from(externalAgents.values());
+export function getExternalAgents(mode?: ClientNetworkMode): ExternalAgent[] {
+  const agents = Array.from(externalAgents.values());
+  if (!mode) return agents;
+  return agents.filter((agent) => isAgentOnNetwork(agent.chain, mode));
 }
 
 /**
  * Get a specific external agent
  */
-export function getExternalAgent(id: string): ExternalAgent | undefined {
-  return externalAgents.get(id);
+export function getExternalAgent(id: string, mode?: ClientNetworkMode): ExternalAgent | undefined {
+  if (mode) {
+    return externalAgents.get(getExternalAgentStorageKey(id, getNetworkConfig(mode).routeLabel));
+  }
+  return Array.from(externalAgents.values()).find((agent) => agent.id === id);
 }
 
 /**
  * Remove an external agent
  */
-export function removeAgent(id: string): boolean {
-  const existed = externalAgents.delete(id);
+export function removeAgent(id: string, mode?: ClientNetworkMode): boolean {
+  if (!mode) {
+    const keys = Array.from(externalAgents.keys()).filter((key) => key.startsWith(`${id}::`));
+    for (const key of keys) externalAgents.delete(key);
+    if (keys.length > 0) saveAgents();
+    return keys.length > 0;
+  }
+  const existed = externalAgents.delete(getExternalAgentStorageKey(id, getNetworkConfig(mode).routeLabel));
   if (existed) saveAgents();
   return existed;
 }
@@ -282,8 +313,8 @@ export function removeAgent(id: string): boolean {
 /**
  * Health check an external agent
  */
-export async function healthCheckAgent(id: string): Promise<boolean> {
-  const agent = externalAgents.get(id);
+export async function healthCheckAgent(id: string, mode: ClientNetworkMode = 'testnet'): Promise<boolean> {
+  const agent = getExternalAgent(id, mode);
   if (!agent) return false;
 
   try {
@@ -313,9 +344,17 @@ export async function healthCheckAgent(id: string): Promise<boolean> {
  * Call an external agent with a prompt/task
  * Proxies the request to the agent's endpoint and returns the result
  */
-export async function callExternalAgent(id: string, prompt: string, taskType?: string): Promise<SpecialistResult> {
+export async function callExternalAgent(
+  id: string,
+  prompt: string,
+  taskType?: string,
+  mode: ClientNetworkMode = 'testnet'
+): Promise<SpecialistResult> {
   const startTime = Date.now();
-  const agent = externalAgents.get(id);
+  const agent = getExternalAgent(id, mode);
+  const network = getNetworkConfig(mode);
+  const signerClient = getSignerClient(mode);
+  const x402HttpClient = getX402HttpClient(mode);
   
   if (!agent) {
     return {
@@ -363,13 +402,13 @@ export async function callExternalAgent(id: string, prompt: string, taskType?: s
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30000); // 30s timeout
 
-    const requestBody = {
-      prompt,
-      taskType: effectiveType,
-      // For Sentinel-specific audit endpoint
-      contractAddress: extractContractAddress(prompt),
-      chain: 'base-sepolia',
-    };
+      const requestBody = {
+        prompt,
+        taskType: effectiveType,
+        // For Sentinel-specific audit endpoint
+        contractAddress: extractContractAddress(prompt),
+        chain: network.routeLabel,
+      };
 
     let lastError: any;
     let successfulResponse: any = null;
@@ -572,7 +611,7 @@ export async function callExternalAgent(id: string, prompt: string, taskType?: s
           ? String(Number(x402Payment.amount) / 1_000_000) // Convert from micro-USDC
           : String(agent.pricing[effectiveType] || agent.pricing['generic'] || 0),
         currency: 'USDC',
-        network: 'base',
+        network: x402Payment?.network || network.routeLabel,
         recipient: x402Payment?.payTo || agent.wallet,
         txHash: x402Payment?.txHash,
       },
@@ -607,7 +646,7 @@ function extractContractAddress(prompt: string): string | undefined {
  * Check if a specialist ID refers to an external agent
  */
 export function isExternalAgent(specialistId: string): boolean {
-  return externalAgents.has(specialistId);
+  return Array.from(externalAgents.values()).some((agent) => agent.id === specialistId);
 }
 
 export default {

--- a/backend/src/fallback-chain.ts
+++ b/backend/src/fallback-chain.ts
@@ -6,6 +6,7 @@
 import { RankedAgent, SpecialistResult, SpecialistType } from './types';
 import { capabilityMatcher } from './capability-matcher';
 import { circuitBreaker } from './circuit-breaker';
+import type { ClientNetworkMode } from './utils/client-network';
 
 export interface FallbackOptions {
   maxRetries?: number;
@@ -16,13 +17,17 @@ export class FallbackChainService {
   /**
    * Build an ordered list of candidate agents for a specific capability/intent
    */
-  async buildFallbackChain(prompt: string, excludeAgents: string[] = []): Promise<RankedAgent[]> {
+  async buildFallbackChain(
+    prompt: string,
+    excludeAgents: string[] = [],
+    networkMode: ClientNetworkMode = 'testnet'
+  ): Promise<RankedAgent[]> {
     try {
       // 1. Extract intent from prompt (or use capability string directly as requiredCapabilities)
       const intent = await capabilityMatcher.extractIntent(prompt);
       
       // 2. Match agents
-      let candidates = await capabilityMatcher.matchAgents(intent);
+      let candidates = await capabilityMatcher.matchAgents(intent, networkMode);
       
       // 3. Filter out excluded agents and those with OPEN circuit breakers
       candidates = candidates.filter(agent => 

--- a/backend/src/payments.ts
+++ b/backend/src/payments.ts
@@ -8,9 +8,10 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import config from './config';
 import { PaymentRecord } from './types';
 import axios from 'axios';
+import { getNetworkConfig } from './utils/network-config';
+import type { ClientNetworkMode } from './utils/client-network';
 
 // Persistence
 const DATA_DIR = path.join(__dirname, '../data');
@@ -110,27 +111,30 @@ export function logTransaction(record: PaymentRecord): void {
 }
 
 /**
- * Get all transaction records
+ * Get transaction records, optionally filtered to a specific network.
  */
-export function getTransactionLog(): PaymentRecord[] {
-  return [...transactionLog];
+export function getTransactionLog(mode?: ClientNetworkMode): PaymentRecord[] {
+  if (!mode) return [...transactionLog];
+  const network = getNetworkConfig(mode);
+  return transactionLog.filter((record) => record.network === network.routeLabel || record.network === network.eip155);
 }
 
 /**
- * Get treasury balance on Base Sepolia (USDC + ETH)
+ * Get treasury balance on the selected Base network (USDC + ETH)
  */
-export async function getTreasuryBalance(): Promise<{ eth: number; usdc: number }> {
-  const treasuryAddress = process.env.TREASURY_WALLET_EVM || '0x676fF3d546932dE6558a267887E58e39f405B135';
-  const usdcAddress = config.base.usdcAddress;
+export async function getTreasuryBalance(mode: ClientNetworkMode = 'testnet'): Promise<{ eth: number; usdc: number }> {
+  const network = getNetworkConfig(mode);
+  const treasuryAddress = network.treasuryAddress;
+  const usdcAddress = network.usdcAddress;
   const paddedAddr = treasuryAddress.replace('0x', '').toLowerCase().padStart(64, '0');
 
   try {
     const [ethRes, usdcRes] = await Promise.all([
-      axios.post(config.base.rpcUrl, {
+      axios.post(network.rpcUrl, {
         jsonrpc: '2.0', method: 'eth_getBalance',
         params: [treasuryAddress, 'latest'], id: 1
       }),
-      axios.post(config.base.rpcUrl, {
+      axios.post(network.rpcUrl, {
         jsonrpc: '2.0', method: 'eth_call',
         params: [{ to: usdcAddress, data: `0x70a08231${paddedAddr}` }, 'latest'], id: 2
       })

--- a/backend/src/routes/agents.ts
+++ b/backend/src/routes/agents.ts
@@ -1,18 +1,25 @@
 import { Router, Request, Response } from 'express';
-import config from '../config';
 import { authMiddleware } from '../middleware/auth';
 import { registerAgent, getExternalAgents, getExternalAgent, healthCheckAgent, removeAgent } from '../external-agents';
 import { RegisterRequest } from '../types';
 import { validateExternalEndpointUrl, revalidateEndpointResolution } from '../utils/ssrf';
 import { getRegistrations } from '../utils/registrations-cache';
+import { normalizeClientNetworkMode } from '../utils/client-network';
+import { getNetworkConfig, getNetworkModeFromChain } from '../utils/network-config';
 
 const router = Router();
 
-router.get('/agents', async (_req: Request, res: Response) => {
+router.get('/agents', async (req: Request, res: Response) => {
   try {
+    const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+    const network = getNetworkConfig(mode);
     const registrations = await getRegistrations();
+    const filtered = registrations.filter((registration: any) => {
+      if (!registration?.chain && !registration?.networkMode) return true;
+      return getNetworkModeFromChain(registration.chain || registration.networkMode) === mode;
+    });
     res.json({
-      agents: registrations.map((r: any, i: number) => ({
+      agents: filtered.map((r: any, i: number) => ({
         agentId: i + 1,
         name: r.name,
         description: r.description,
@@ -20,9 +27,11 @@ router.get('/agents', async (_req: Request, res: Response) => {
         x402Support: r.x402Support,
         supportedTrust: r.supportedTrust,
       })),
-      identityRegistry: config.erc8004.identityRegistry || 'pending-deployment',
-      reputationRegistry: config.erc8004.reputationRegistry || 'pending-deployment',
-      chain: 'Base Sepolia (EIP-155:84532)',
+      identityRegistry: network.identityRegistry || 'pending-deployment',
+      reputationRegistry: network.reputationRegistry || 'pending-deployment',
+      chain: network.displayName,
+      chainId: network.chainId,
+      networkMode: mode,
     });
   } catch (_error: any) {
     res.status(500).json({ error: 'Internal server error' });
@@ -31,12 +40,17 @@ router.get('/agents', async (_req: Request, res: Response) => {
 
 router.get('/agents/:id/registration', async (req: Request, res: Response) => {
   try {
+    const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
     const id = parseInt(req.params.id) - 1;
     const registrations = await getRegistrations();
-    if (id < 0 || id >= registrations.length) {
+    const filtered = registrations.filter((registration: any) => {
+      if (!registration?.chain && !registration?.networkMode) return true;
+      return getNetworkModeFromChain(registration.chain || registration.networkMode) === mode;
+    });
+    if (id < 0 || id >= filtered.length) {
       return res.status(404).json({ error: 'Agent not found' });
     }
-    res.json(registrations[id]);
+    res.json(filtered[id]);
   } catch (_error: any) {
     res.status(500).json({ error: 'Internal server error' });
   }
@@ -113,13 +127,15 @@ router.post('/agents/register', authMiddleware, async (req: Request, res: Respon
   }
 });
 
-router.get('/agents/external', (_req: Request, res: Response) => {
-  const agents = getExternalAgents();
-  res.json({ agents, count: agents.length });
+router.get('/agents/external', (req: Request, res: Response) => {
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+  const agents = getExternalAgents(mode);
+  res.json({ agents, count: agents.length, networkMode: mode });
 });
 
 router.get('/agents/external/:id', (req: Request, res: Response) => {
-  const agent = getExternalAgent(req.params.id);
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+  const agent = getExternalAgent(req.params.id, mode);
   if (!agent) {
     return res.status(404).json({ error: 'External agent not found' });
   }
@@ -127,8 +143,9 @@ router.get('/agents/external/:id', (req: Request, res: Response) => {
 });
 
 router.post('/agents/external/:id/health', authMiddleware, async (req: Request, res: Response) => {
-  const healthy = await healthCheckAgent(req.params.id);
-  const agent = getExternalAgent(req.params.id);
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode || req.body?.networkMode);
+  const healthy = await healthCheckAgent(req.params.id, mode);
+  const agent = getExternalAgent(req.params.id, mode);
   res.json({
     id: req.params.id,
     healthy,
@@ -137,7 +154,8 @@ router.post('/agents/external/:id/health', authMiddleware, async (req: Request, 
 });
 
 router.delete('/agents/external/:id', authMiddleware, (req: Request, res: Response) => {
-  const removed = removeAgent(req.params.id);
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode || req.body?.networkMode);
+  const removed = removeAgent(req.params.id, mode);
   if (!removed) {
     return res.status(404).json({ error: 'External agent not found' });
   }

--- a/backend/src/routes/bazaar.ts
+++ b/backend/src/routes/bazaar.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { discoverAgents, getAgentDetails, probeAgentPricing } from '../bazaar';
+import { normalizeClientNetworkMode } from '../utils/client-network';
+import { getNetworkConfig } from '../utils/network-config';
 
 const router = Router();
 
@@ -15,12 +17,17 @@ router.get('/discovery', async (req: Request, res: Response) => {
     const offset = parseInt(req.query.offset as string) || 0;
     const search = (req.query.search as string) || '';
     const network = (req.query.network as 'mainnet' | 'testnet' | 'all') || 'testnet';
+    const mode = network === 'all' ? 'testnet' : normalizeClientNetworkMode(network);
+    const activeNetwork = getNetworkConfig(mode);
 
     const { agents, total } = await discoverAgents({ limit, offset, search, network });
     res.json({
       agents,
       count: agents.length,
       total,
+      networkMode: network,
+      chainId: activeNetwork.chainId,
+      usdcAddress: activeNetwork.usdcAddress,
       timestamp: new Date().toISOString(),
     });
   } catch (error: any) {

--- a/backend/src/routes/dispatch.ts
+++ b/backend/src/routes/dispatch.ts
@@ -26,6 +26,7 @@ import {
   reliabilityOpsRateLimitMiddleware,
   requireReliabilityOpsAccess,
 } from '../reliability/ops-safety';
+import { getNetworkConfig } from '../utils/network-config';
 
 const router = Router();
 
@@ -59,6 +60,7 @@ router.post('/route-preview', async (req: Request, res: Response) => {
   try {
     const { prompt, hiredAgents, networkMode } = req.body;
     const mode = normalizeClientNetworkMode(networkMode);
+    const network = getNetworkConfig(mode);
     const routeNetwork = toRouteNetworkLabel(mode);
     const executionSupported = isExecutionSupportedForMode(mode);
     if (!prompt || (typeof prompt === 'string' && prompt.trim().length === 0)) {
@@ -91,7 +93,7 @@ router.post('/route-preview', async (req: Request, res: Response) => {
     }
     
     // Simple query — use routing with swarm context
-    const specialist = await routePrompt(prompt, hiredAgents);
+    const specialist = await routePrompt(prompt, hiredAgents, mode);
     
     // Determine fee and estimation confidence
     let fee = 0;
@@ -103,7 +105,7 @@ router.post('/route-preview', async (req: Request, res: Response) => {
       showEstimate = true; // Internal agents have fixed pricing
     } else {
       // Check external agent registry
-      const externalAgent = getExternalAgent(specialist);
+      const externalAgent = getExternalAgent(specialist, mode);
       if (externalAgent) {
         // Use generic pricing or fallback to 0.10
         fee = externalAgent.pricing?.generic || 0.10;
@@ -115,7 +117,19 @@ router.post('/route-preview', async (req: Request, res: Response) => {
       }
     }
 
-    res.json({ specialist, fee, currency: 'USDC', network: routeNetwork, networkMode: mode, executionSupported, showEstimate });
+    res.json({
+      specialist,
+      fee,
+      currency: 'USDC',
+      network: routeNetwork,
+      networkMode: mode,
+      executionSupported,
+      showEstimate,
+      chainId: network.chainId,
+      usdcAddress: network.usdcAddress,
+      identityRegistry: network.identityRegistry || 'pending-deployment',
+      reputationRegistry: network.reputationRegistry || 'pending-deployment',
+    });
   } catch (err: any) {
     res.status(500).json({ error: err.message });
   }

--- a/backend/src/routes/general.ts
+++ b/backend/src/routes/general.ts
@@ -7,21 +7,25 @@ import magos from '../specialists/magos';
 import aura from '../specialists/aura';
 import bankr from '../specialists/bankr';
 import { hasErc8128Headers, verifyErc8128Request } from '../middleware/erc8128-auth';
+import { normalizeClientNetworkMode } from '../utils/client-network';
+import { getNetworkConfig } from '../utils/network-config';
 // Note: x402 payment enforcement is handled at app level by x402-server.ts
 // The manual paymentMiddleware in middleware/payment.ts is kept as fallback
 
 const router = Router();
-const TREASURY_WALLET_EVM = '0x676fF3d546932dE6558a267887E58e39f405B135';
 
 /**
  * Health check
  */
 router.get('/health', (req: Request, res: Response) => {
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+  const network = getNetworkConfig(mode);
   res.json({
     status: 'ok',
     service: 'Hivemind Protocol',
     version: '0.6.0',
-    chain: 'Base Sepolia (EIP-155:84532)',
+    chain: network.displayName,
+    networkMode: mode,
     trustLayer: 'ERC-8004',
     auth: ['api-key', 'erc8128'],
     llmRouter: 'ClawRouter/BlockRun',
@@ -34,18 +38,21 @@ router.get('/health', (req: Request, res: Response) => {
  */
 router.get('/status', async (req: Request, res: Response) => {
   try {
-    const balances = await getTreasuryBalance();
+    const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+    const network = getNetworkConfig(mode);
+    const balances = await getTreasuryBalance(mode);
 
     res.json({
       status: 'ok',
       treasury: {
-        address: TREASURY_WALLET_EVM,
+        address: network.treasuryAddress,
         balances: {
           eth: balances.eth,
           usdc: balances.usdc,
         },
       },
-      chain: 'Base Sepolia (EIP-155:84532)',
+      chain: network.displayName,
+      networkMode: mode,
       specialists: ['magos', 'aura', 'bankr', 'seeker', 'scribe'],
       uptime: process.uptime(),
     });
@@ -122,7 +129,7 @@ router.get('/v1/specialists', (req: Request, res: Response) => {
 router.post(['/specialist/:id', '/query/:id'], async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
-    const { prompt } = req.body;
+    const { prompt, networkMode } = req.body;
     
     // Validate specialist ID (with aliases)
     const specialistAliases: Record<string, string> = {
@@ -144,7 +151,9 @@ router.post(['/specialist/:id', '/query/:id'], async (req: Request, res: Respons
     }
 
     // Payment verified or not required by middleware - execute specialist
-    const result = await callSpecialist(resolvedId as SpecialistType, prompt);
+    const result = await callSpecialist(resolvedId as SpecialistType, prompt, {
+      metadata: { networkMode: normalizeClientNetworkMode(networkMode) },
+    });
     res.json(result);
   } catch (error: any) {
     res.status(500).json({ error: "Internal server error" });

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -2,10 +2,10 @@ import { Router, Request, Response } from 'express';
 import { getTreasuryBalance, getTransactionLog, logTransaction } from '../payments';
 import { createWalletClient, createPublicClient, http, parseUnits } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { baseSepolia } from 'viem/chains';
+import { normalizeClientNetworkMode } from '../utils/client-network';
+import { getNetworkConfig } from '../utils/network-config';
 
 const router = Router();
-const TREASURY_WALLET_EVM = '0x676fF3d546932dE6558a267887E58e39f405B135';
 
 /**
  * Delegated payment — pull USDC from user's wallet via ERC-20 approval.
@@ -14,7 +14,9 @@ const TREASURY_WALLET_EVM = '0x676fF3d546932dE6558a267887E58e39f405B135';
  */
 router.post('/delegate-pay', async (req: Request, res: Response) => {
   try {
-    const { userAddress, amount, specialist } = req.body;
+    const { userAddress, amount, specialist, networkMode } = req.body;
+    const mode = normalizeClientNetworkMode(networkMode);
+    const network = getNetworkConfig(mode);
     if (!userAddress || !amount) {
       return res.status(400).json({ error: 'userAddress and amount required' });
     }
@@ -35,18 +37,18 @@ router.post('/delegate-pay', async (req: Request, res: Response) => {
 
     // viem imports are now static at top of file
     const account = privateKeyToAccount(privateKey as `0x${string}`);
-    const TREASURY = TREASURY_WALLET_EVM as `0x${string}`;
-    const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' as `0x${string}`;
+    const TREASURY = network.treasuryAddress;
+    const USDC = network.usdcAddress;
     const amountWei = parseUnits(String(amount), 6);
 
     const walletClient = createWalletClient({
       account,
-      chain: baseSepolia,
-      transport: http(),
+      chain: network.chain,
+      transport: http(network.rpcUrl),
     });
     const publicClient = createPublicClient({
-      chain: baseSepolia,
-      transport: http(),
+      chain: network.chain,
+      transport: http(network.rpcUrl),
     });
 
     // Pull USDC from user's wallet to treasury via their on-chain approval
@@ -66,7 +68,7 @@ router.post('/delegate-pay', async (req: Request, res: Response) => {
       }],
       functionName: 'transferFrom',
       args: [userAddress as `0x${string}`, TREASURY, amountWei],
-      chain: baseSepolia,
+      chain: network.chain,
     });
 
     await publicClient.waitForTransactionReceipt({ hash, timeout: 30_000 });
@@ -76,7 +78,7 @@ router.post('/delegate-pay', async (req: Request, res: Response) => {
     logTransaction({
       amount: String(amount),
       currency: 'USDC',
-      network: 'base-sepolia',
+      network: network.routeLabel,
       recipient: specialist || 'unknown',
       txHash: hash,
       status: 'completed',
@@ -87,7 +89,9 @@ router.post('/delegate-pay', async (req: Request, res: Response) => {
     res.json({ 
       success: true, 
       txHash: hash,
-      explorer: `https://sepolia.basescan.org/tx/${hash}`,
+      explorer: `${network.explorerBase}/tx/${hash}`,
+      network: network.routeLabel,
+      networkMode: mode,
     });
   } catch (err: any) {
     console.error('[delegate-pay] Failed:', err.message);
@@ -101,10 +105,15 @@ router.post('/delegate-pay', async (req: Request, res: Response) => {
  */
 router.get('/wallet/balances', async (req: Request, res: Response) => {
   try {
-    const balances = await getTreasuryBalance();
+    const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+    const network = getNetworkConfig(mode);
+    const balances = await getTreasuryBalance(mode);
     res.json({
-      address: TREASURY_WALLET_EVM,
-      chain: 'base-sepolia',
+      address: network.treasuryAddress,
+      chain: network.routeLabel,
+      networkMode: mode,
+      chainId: network.chainId,
+      usdcAddress: network.usdcAddress,
       balances,
     });
   } catch (error: any) {
@@ -117,8 +126,9 @@ router.get('/wallet/balances', async (req: Request, res: Response) => {
  * GET /wallet/transactions
  */
 router.get('/wallet/transactions', (req: Request, res: Response) => {
-  const transactions = getTransactionLog();
-  res.json({ transactions, count: transactions.length });
+  const mode = normalizeClientNetworkMode(req.query.network || req.query.networkMode);
+  const transactions = getTransactionLog(mode);
+  res.json({ transactions, count: transactions.length, networkMode: mode });
 });
 
 /**

--- a/backend/src/specialists/bankr.ts
+++ b/backend/src/specialists/bankr.ts
@@ -11,6 +11,7 @@ import * as path from 'path';
 import { BankrAction, SpecialistResult } from '../types';
 import config from '../config';
 import { getPrice } from './tools/coingecko';
+import { getNetworkConfig } from '../utils/network-config';
 // Solana integration removed — Base-only in V2
 
 const AGENTWALLET_API = config.agentWallet.apiUrl;
@@ -704,10 +705,15 @@ export const bankr = {
         const isApproved = context?.metadata?.transactionApproved === true;
         if (!isApproved) {
           console.log(`[bankr] Transaction requires approval: ${intent.type} ${amount} ${fromToken}`);
+          const networkMode = context?.metadata?.networkMode === 'mainnet' ? 'mainnet' : 'testnet';
+          const network = getNetworkConfig(networkMode);
           
           let estimatedOutput = '0';
           let route = 'Direct';
           let feeEstimate = '0.000005 SOL';
+          const transferSummary = intent.type === 'transfer' && intent.address?.startsWith('0x')
+            ? `Ready to sign ${intent.amount} ${fromToken.toUpperCase()} on ${network.chainName}.`
+            : undefined;
 
           if (intent.type === 'swap') {
             const inputMint = TOKEN_MINTS[intent.from!.toUpperCase()] || intent.from!;
@@ -730,6 +736,7 @@ export const bankr = {
             data: {
               type: intent.type,
               requiresApproval: true,
+              summary: transferSummary,
               details: {
                 type: intent.type,
                 amount: intent.amount,
@@ -740,6 +747,11 @@ export const bankr = {
                 route: intent.type === 'swap' ? route : undefined,
                 feeEstimate,
                 currentBalance: currentBalance.toFixed(4),
+                chain: intent.type === 'transfer' && intent.address?.startsWith('0x') ? network.chainName : undefined,
+                network: intent.type === 'transfer' && intent.address?.startsWith('0x') ? network.routeLabel : undefined,
+                chainId: intent.type === 'transfer' && intent.address?.startsWith('0x') ? network.chainId : undefined,
+                usdcContract: intent.type === 'transfer' && intent.address?.startsWith('0x') ? network.usdcAddress : undefined,
+                explorer: intent.type === 'transfer' && intent.address?.startsWith('0x') ? `${network.explorerBase}/address/${intent.address}` : undefined,
               }
             },
             timestamp: new Date(),
@@ -798,6 +810,8 @@ export const bankr = {
             // Check if it's an EVM address (0x...)
             if (intent.address.startsWith('0x')) {
               const transferAmount = intent.amount || '5';
+              const networkMode = context?.metadata?.networkMode === 'mainnet' ? 'mainnet' : 'testnet';
+              const network = getNetworkConfig(networkMode);
               data = {
                 type: 'transfer',
                 status: 'pending',
@@ -806,14 +820,15 @@ export const bankr = {
                   to: intent.address,
                   amount: transferAmount,
                   asset: transferAsset,
-                  chain: 'Base Sepolia',
-                  network: 'base-sepolia',
-                  usdcContract: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-                  explorer: `https://sepolia.basescan.org/address/${intent.address}`,
-                  note: `Sign with your connected wallet to send ${transferAmount} ${transferAsset} on Base Sepolia.`,
+                  chain: network.chainName,
+                  network: network.routeLabel,
+                  chainId: network.chainId,
+                  usdcContract: network.usdcAddress,
+                  explorer: `${network.explorerBase}/address/${intent.address}`,
+                  note: `Sign with your connected wallet to send ${transferAmount} ${transferAsset} on ${network.chainName}.`,
                 },
               };
-              data.summary = `💸 **Base Sepolia Transfer Ready**\n• Amount: ${transferAmount} ${transferAsset}\n• To: ${intent.address.slice(0, 6)}...${intent.address.slice(-4)}\n• Chain: Base Sepolia\n• Status: Awaiting wallet signature\n\n_Sign the transaction in your connected wallet to complete._`;
+              data.summary = `💸 **${network.chainName} Transfer Ready**\n• Amount: ${transferAmount} ${transferAsset}\n• To: ${intent.address.slice(0, 6)}...${intent.address.slice(-4)}\n• Chain: ${network.chainName}\n• Status: Awaiting wallet signature\n\n_Sign the transaction in your connected wallet to complete._`;
               break;
             }
             // Solana address — check if asset is USDC (SPL token transfer) or SOL

--- a/backend/src/utils/client-network.ts
+++ b/backend/src/utils/client-network.ts
@@ -2,7 +2,22 @@ export type ClientNetworkMode = 'testnet' | 'mainnet';
 
 export function normalizeClientNetworkMode(input: unknown): ClientNetworkMode {
   const value = String(input || '').toLowerCase();
-  if (value === 'mainnet' || value.includes('8453')) return 'mainnet';
+  if (
+    value === 'testnet' ||
+    value.includes('84532') ||
+    value.includes('base-sepolia') ||
+    value.includes('eip155:84532')
+  ) {
+    return 'testnet';
+  }
+  if (
+    value === 'mainnet' ||
+    value.includes('eip155:8453') ||
+    value.includes('base-mainnet') ||
+    /(^|[^0-9])8453([^0-9]|$)/.test(value)
+  ) {
+    return 'mainnet';
+  }
   return 'testnet';
 }
 

--- a/backend/src/utils/network-config.ts
+++ b/backend/src/utils/network-config.ts
@@ -1,0 +1,94 @@
+import { base, baseSepolia } from 'viem/chains';
+import type { ClientNetworkMode } from './client-network';
+
+export interface HivemindNetworkConfig {
+  mode: ClientNetworkMode;
+  chain: typeof base | typeof baseSepolia;
+  chainId: number;
+  chainName: string;
+  displayName: string;
+  routeLabel: 'base-mainnet' | 'base-sepolia';
+  eip155: `eip155:${number}`;
+  explorerBase: string;
+  rpcUrl: string;
+  usdcAddress: `0x${string}`;
+  facilitatorUrl: string;
+  identityRegistry: string;
+  reputationRegistry: string;
+  treasuryAddress: `0x${string}`;
+  delegateAddress: `0x${string}`;
+}
+
+const DEFAULT_TREASURY = '0x676fF3d546932dE6558a267887E58e39f405B135' as const;
+const DEFAULT_DELEGATE = '0x4a9948159B7e6c19301ebc388E72B1EdFf87187B' as const;
+
+const NETWORK_CONFIGS: Record<ClientNetworkMode, HivemindNetworkConfig> = {
+  testnet: {
+    mode: 'testnet',
+    chain: baseSepolia,
+    chainId: 84532,
+    chainName: 'Base Sepolia',
+    displayName: 'Base Sepolia (EIP-155:84532)',
+    routeLabel: 'base-sepolia',
+    eip155: 'eip155:84532',
+    explorerBase: 'https://sepolia.basescan.org',
+    rpcUrl: process.env.BASE_TESTNET_RPC_URL || process.env.BASE_RPC_URL || 'https://sepolia.base.org',
+    usdcAddress: (process.env.BASE_TESTNET_USDC_ADDRESS || process.env.BASE_USDC_ADDRESS || '0x036CbD53842c5426634e7929541eC2318f3dCF7e') as `0x${string}`,
+    facilitatorUrl: process.env.X402_TESTNET_FACILITATOR_URL || process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator',
+    identityRegistry: process.env.ERC8004_TESTNET_IDENTITY_REGISTRY || process.env.ERC8004_IDENTITY_REGISTRY || '',
+    reputationRegistry: process.env.ERC8004_TESTNET_REPUTATION_REGISTRY || process.env.ERC8004_REPUTATION_REGISTRY || '',
+    treasuryAddress: (process.env.TREASURY_WALLET_EVM_TESTNET || process.env.TREASURY_WALLET_EVM || DEFAULT_TREASURY) as `0x${string}`,
+    delegateAddress: (process.env.DELEGATE_WALLET_EVM_TESTNET || process.env.DELEGATE_WALLET_EVM || DEFAULT_DELEGATE) as `0x${string}`,
+  },
+  mainnet: {
+    mode: 'mainnet',
+    chain: base,
+    chainId: 8453,
+    chainName: 'Base Mainnet',
+    displayName: 'Base Mainnet (EIP-155:8453)',
+    routeLabel: 'base-mainnet',
+    eip155: 'eip155:8453',
+    explorerBase: 'https://basescan.org',
+    rpcUrl: process.env.BASE_MAINNET_RPC_URL || 'https://mainnet.base.org',
+    usdcAddress: (process.env.BASE_MAINNET_USDC_ADDRESS || '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913') as `0x${string}`,
+    facilitatorUrl: process.env.X402_MAINNET_FACILITATOR_URL || process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator',
+    identityRegistry: process.env.ERC8004_MAINNET_IDENTITY_REGISTRY || '',
+    reputationRegistry: process.env.ERC8004_MAINNET_REPUTATION_REGISTRY || '',
+    treasuryAddress: (process.env.TREASURY_WALLET_EVM_MAINNET || process.env.TREASURY_WALLET_EVM || DEFAULT_TREASURY) as `0x${string}`,
+    delegateAddress: (process.env.DELEGATE_WALLET_EVM_MAINNET || process.env.DELEGATE_WALLET_EVM || DEFAULT_DELEGATE) as `0x${string}`,
+  },
+};
+
+export function getNetworkConfig(mode: ClientNetworkMode = 'testnet'): HivemindNetworkConfig {
+  return NETWORK_CONFIGS[mode];
+}
+
+export function getNetworkModeFromChain(value: string | number | undefined | null): ClientNetworkMode {
+  const normalized = String(value || '').toLowerCase();
+  if (
+    normalized === 'testnet' ||
+    normalized.includes('84532') ||
+    normalized.includes('base-sepolia') ||
+    normalized.includes('eip155:84532')
+  ) {
+    return 'testnet';
+  }
+  if (
+    normalized === 'mainnet' ||
+    normalized.includes('eip155:8453') ||
+    normalized.includes('base-mainnet') ||
+    /(^|[^0-9])8453([^0-9]|$)/.test(normalized)
+  ) {
+    return 'mainnet';
+  }
+  return 'testnet';
+}
+
+export function getNetworkConfigFromChain(value: string | number | undefined | null): HivemindNetworkConfig {
+  return getNetworkConfig(getNetworkModeFromChain(value));
+}
+
+export function isAgentOnNetwork(agentChain: string | undefined, mode: ClientNetworkMode): boolean {
+  if (!agentChain) return mode === 'testnet';
+  return getNetworkModeFromChain(agentChain) === mode;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -22,14 +22,22 @@ import {
   PaymentFlow,
   NetworkModeToggle,
 } from '@/components';
-import { DelegationPanel, getDelegationState, recordDelegationSpend, getDelegationTotalSpent } from '@/components/DelegationPanel';
+import { DelegationPanel, getDelegationState, recordDelegationSpend } from '@/components/DelegationPanel';
 import { useAccount } from 'wagmi';
 import { AgentDetailModal } from '@/components/AgentDetailModal';
 import { ActivityFeed, ActivityItem } from '@/components/ActivityFeed';
 import { useWebSocket } from '@/hooks/useWebSocket';
 import type { SpecialistType, QueryHistoryItem } from '@/types';
 import { LayoutGrid, Zap, Shield, ArrowRight, DollarSign, Globe, Terminal } from 'lucide-react';
-import { NETWORK_MODE_STORAGE_KEY, NETWORK_MODE_LABELS, getExplorerTxUrl, resolveNetworkMode, supportsDirectPayments } from '@/lib/networkMode';
+import {
+  getExplorerTxUrl,
+  getModeScopedStorageKey,
+  NETWORK_MODE_EVENT,
+  NETWORK_MODE_LABELS,
+  NETWORK_MODE_STORAGE_KEY,
+  resolveNetworkMode,
+  supportsDirectPayments,
+} from '@/lib/networkMode';
 import type { NetworkMode } from '@/types';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
@@ -70,15 +78,26 @@ export default function CommandCenter() {
   const [selectedAgent, setSelectedAgent] = useState<SpecialistType | null>(null);
   const [activityItems, setActivityItems] = useState<ActivityItem[]>([]);
   const [preSelectedAgent, setPreSelectedAgent] = useState<string | null>(null);
+  const [networkMode, setNetworkMode] = useState<NetworkMode>(() => {
+    if (typeof window === 'undefined') return 'testnet';
+    return resolveNetworkMode(localStorage.getItem(NETWORK_MODE_STORAGE_KEY));
+  });
   const [hiredAgents, setHiredAgents] = useState<string[]>(() => {
     if (typeof window === 'undefined') return ['bankr', 'scribe', 'seeker'];
     try {
-      const saved = localStorage.getItem('hivemind-swarm');
+      const saved = localStorage.getItem(getModeScopedStorageKey('hivemind-swarm', resolveNetworkMode(localStorage.getItem(NETWORK_MODE_STORAGE_KEY))));
       if (saved) return JSON.parse(saved);
     } catch {}
     return ['bankr', 'scribe', 'seeker'];
   });
-  const [customInstructions, setCustomInstructions] = useState<Record<string, string>>({});
+  const [customInstructions, setCustomInstructions] = useState<Record<string, string>>(() => {
+    if (typeof window === 'undefined') return {};
+    try {
+      const saved = localStorage.getItem(getModeScopedStorageKey('hivemind-custom-instructions', resolveNetworkMode(localStorage.getItem(NETWORK_MODE_STORAGE_KEY))));
+      if (saved) return JSON.parse(saved);
+    } catch {}
+    return {};
+  });
   // Store metadata for external registry agents (description, capabilities, color, price)
   const [registryMeta, setRegistryMeta] = useState<Record<string, {
     name: string;
@@ -89,7 +108,7 @@ export default function CommandCenter() {
   }>>(() => {
     if (typeof window === 'undefined') return {};
     try {
-      const saved = localStorage.getItem('hivemind-registry-meta');
+      const saved = localStorage.getItem(getModeScopedStorageKey('hivemind-registry-meta', resolveNetworkMode(localStorage.getItem(NETWORK_MODE_STORAGE_KEY))));
       if (saved) return JSON.parse(saved);
     } catch {}
     return {};
@@ -138,11 +157,6 @@ export default function CommandCenter() {
     prompt: string;
     transferTo?: string;
   } | null>(null);
-  const [networkMode, setNetworkMode] = useState<NetworkMode>(() => {
-    if (typeof window === 'undefined') return 'testnet';
-    const stored = localStorage.getItem(NETWORK_MODE_STORAGE_KEY);
-    return stored === 'mainnet' ? 'mainnet' : 'testnet';
-  });
 
   const {
     isConnected,
@@ -157,20 +171,62 @@ export default function CommandCenter() {
   } = useWebSocket();
 
   const [showMobileGraph, setShowMobileGraph] = useState(false);
+  const swarmStorageKey = getModeScopedStorageKey('hivemind-swarm', networkMode);
+  const registryMetaStorageKey = getModeScopedStorageKey('hivemind-registry-meta', networkMode);
+  const customInstructionsStorageKey = getModeScopedStorageKey('hivemind-custom-instructions', networkMode);
 
   // Persist swarm agents
   useEffect(() => {
-    localStorage.setItem('hivemind-swarm', JSON.stringify(hiredAgents));
-  }, [hiredAgents]);
+    localStorage.setItem(swarmStorageKey, JSON.stringify(hiredAgents));
+  }, [hiredAgents, swarmStorageKey]);
 
   // Persist registry metadata
   useEffect(() => {
-    localStorage.setItem('hivemind-registry-meta', JSON.stringify(registryMeta));
-  }, [registryMeta]);
+    localStorage.setItem(registryMetaStorageKey, JSON.stringify(registryMeta));
+  }, [registryMeta, registryMetaStorageKey]);
+
+  useEffect(() => {
+    localStorage.setItem(customInstructionsStorageKey, JSON.stringify(customInstructions));
+  }, [customInstructions, customInstructionsStorageKey]);
 
   useEffect(() => {
     localStorage.setItem(NETWORK_MODE_STORAGE_KEY, networkMode);
+    window.dispatchEvent(new CustomEvent(NETWORK_MODE_EVENT, { detail: networkMode }));
   }, [networkMode]);
+
+  useEffect(() => {
+    try {
+      const savedSwarm = localStorage.getItem(swarmStorageKey);
+      setHiredAgents(savedSwarm ? JSON.parse(savedSwarm) : ['bankr', 'scribe', 'seeker']);
+    } catch {
+      setHiredAgents(['bankr', 'scribe', 'seeker']);
+    }
+
+    try {
+      const savedMeta = localStorage.getItem(registryMetaStorageKey);
+      setRegistryMeta(savedMeta ? JSON.parse(savedMeta) : {});
+    } catch {
+      setRegistryMeta({});
+    }
+
+    try {
+      const savedInstructions = localStorage.getItem(customInstructionsStorageKey);
+      setCustomInstructions(savedInstructions ? JSON.parse(savedInstructions) : {});
+    } catch {
+      setCustomInstructions({});
+    }
+
+    setCurrentTaskId(null);
+    setPreSelectedAgent(null);
+    setShowAddToSwarm(null);
+    setPaymentRequired(null);
+    setPendingApproval(null);
+    setLastResult(null);
+    setActivityItems([]);
+    setError(null);
+    setIsLoading(false);
+    reset();
+  }, [customInstructionsStorageKey, networkMode, registryMetaStorageKey, reset, swarmStorageKey]);
 
   // Persistence for query history
   useEffect(() => {
@@ -533,7 +589,7 @@ export default function CommandCenter() {
             }
             if (fee > 0) {
               // Check for delegation (auto-pay)
-              const delegation = getDelegationState();
+              const delegation = getDelegationState(networkMode);
               const remaining = delegation ? Math.max(0, Number(delegation.allowance || 0) - Number(delegation.spent || 0)) : 0;
 
               console.log('[pre-pay] Delegation check:', {
@@ -560,7 +616,7 @@ export default function CommandCenter() {
                   if (delegateRes.ok) {
                     const delegateData = await delegateRes.json();
                     headers['X-Payment-Proof'] = delegateData.txHash;
-                    recordDelegationSpend(fee, preview.specialist, delegateData.txHash);
+                    recordDelegationSpend(networkMode, fee, preview.specialist, delegateData.txHash);
 
                     // Record in Agent Payments
                     const feePayment = {
@@ -1091,8 +1147,8 @@ export default function CommandCenter() {
                     animate={{ opacity: 1, x: 0 }}
                     transition={{ delay: 0.3 }}
                   >
-                    <WalletPanel />
-                    <DelegationPanel />
+                    <WalletPanel networkMode={networkMode} />
+                    <DelegationPanel networkMode={networkMode} />
                   </motion.div>
 
                   {/* Payment Feed */}
@@ -1147,6 +1203,7 @@ export default function CommandCenter() {
               <BazaarRegistry
                 onAddToSwarm={handleBazaarAdd}
                 hiredAgents={hiredAgents}
+                networkMode={networkMode}
               />
             </motion.div>
           ) : (
@@ -1334,6 +1391,7 @@ export default function CommandCenter() {
         <TransactionApproval
           isOpen={true}
           details={pendingTransaction}
+          networkMode={networkMode}
           onApprove={handleApproveTransaction}
           onReject={handleRejectTransaction}
         />

--- a/frontend/src/components/BazaarRegistry.tsx
+++ b/frontend/src/components/BazaarRegistry.tsx
@@ -15,6 +15,7 @@ import {
   Shield,
   ExternalLink
 } from 'lucide-react';
+import { getNetworkConfig, resolveNetworkMode, type NetworkMode } from '@/lib/networkMode';
 
 interface DiscoveredAgent {
   id: string;
@@ -70,9 +71,11 @@ const CHAIN_COLORS: Record<number, string> = {
 interface BazaarRegistryProps {
   onAddToSwarm: (agent: any) => Promise<void>;
   hiredAgents: string[];
+  networkMode: NetworkMode;
 }
 
-export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProps) {
+export function BazaarRegistry({ onAddToSwarm, hiredAgents, networkMode }: BazaarRegistryProps) {
+  const network = getNetworkConfig(networkMode);
   const [agents, setAgents] = useState<DiscoveredAgent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
@@ -85,13 +88,13 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
     setIsLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({ limit: '50' });
+      const params = new URLSearchParams({ limit: '50', network: networkMode });
       if (search) params.set('search', search);
       
       // Fetch from both 8004scan discovery AND locally registered external agents
       const [discoveryRes, externalRes] = await Promise.all([
         fetch(`${API_URL}/api/bazaar/discovery?${params}`),
-        fetch(`${API_URL}/api/agents/external`).catch(() => null),
+        fetch(`${API_URL}/api/agents/external?network=${networkMode}`).catch(() => null),
       ]);
 
       let allAgents: DiscoveredAgent[] = [];
@@ -119,7 +122,7 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
             id: ext.id,
             agentId: `agent:base:${ext.wallet?.slice(0, 6)}...${ext.wallet?.slice(-3)}`,
             tokenId: '',
-            chainId: 84532,
+            chainId: resolveNetworkMode(ext.chain) === 'mainnet' ? 8453 : 84532,
             name: ext.name,
             description: ext.description || '',
             wallet: ext.wallet || '',
@@ -137,7 +140,7 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
             createdAt: ext.registeredAt || '',
             pricing: ext.pricing ? { 
               amount: ext.pricing['security-audit'] || ext.pricing['generic'] || Object.values(ext.pricing)[0] || 0, 
-              network: `eip155:84532`, 
+              network: resolveNetworkMode(ext.chain) === 'mainnet' ? 'eip155:8453' : 'eip155:84532',
               payTo: ext.wallet 
             } : undefined,
           });
@@ -156,7 +159,7 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
 
   useEffect(() => {
     fetchAgents();
-  }, []);
+  }, [networkMode]);
 
   const handleSearch = () => {
     setSearchQuery(searchInput);
@@ -243,6 +246,7 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
         pricing,
         chain: `eip155:${agent.chainId}`,
         erc8004Id: agent.agentId,
+        networkMode,
       };
 
       await onAddToSwarm(agentPayload);
@@ -277,7 +281,7 @@ export function BazaarRegistry({ onAddToSwarm, hiredAgents }: BazaarRegistryProp
             Agent Registry
           </h2>
           <p className="text-sm text-[var(--text-muted)] mt-1">
-            Discover ERC-8004 agents with x402 payments — {total.toLocaleString()} registered
+            Discover ERC-8004 agents with x402 payments on {network.chainName} — {total.toLocaleString()} registered
           </p>
         </div>
 

--- a/frontend/src/components/DelegationPanel.tsx
+++ b/frontend/src/components/DelegationPanel.tsx
@@ -2,14 +2,11 @@
 
 import { useState, useEffect } from 'react';
 import { Shield, ShieldCheck, Zap, Loader2, X } from 'lucide-react';
-import { useAccount, useWriteContract, useWaitForTransactionReceipt } from 'wagmi';
+import { useAccount, useWriteContract } from 'wagmi';
 import { parseUnits } from 'viem';
-import { baseSepolia } from 'wagmi/chains';
+import { getExplorerTxUrl, getModeScopedStorageKey, getNetworkConfig, type NetworkMode } from '@/lib/networkMode';
 
-// The address that the backend uses to call transferFrom on behalf of the user.
-// This is the demo wallet — user approves THIS address to spend their USDC.
-const DELEGATE_ADDRESS = '0x4a9948159B7e6c19301ebc388E72B1EdFf87187B' as `0x${string}`;
-const USDC_ADDRESS = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' as `0x${string}`;
+const DELEGATION_STORAGE_KEY = 'hivemind-delegation';
 
 const USDC_APPROVE_ABI = [{
   name: 'approve',
@@ -23,6 +20,10 @@ const USDC_APPROVE_ABI = [{
 }] as const;
 
 interface DelegationState {
+  networkMode: NetworkMode;
+  chainId: number;
+  delegateAddress: string;
+  usdcAddress: string;
   enabled: boolean;
   allowance: number;
   spent: number;
@@ -31,22 +32,27 @@ interface DelegationState {
   payments: { amount: number; specialist: string; txHash: string; timestamp: string }[];
 }
 
-export function getDelegationState(): DelegationState | null {
+function getDelegationStorageKey(mode: NetworkMode): string {
+  return getModeScopedStorageKey(DELEGATION_STORAGE_KEY, mode);
+}
+
+export function getDelegationState(mode: NetworkMode): DelegationState | null {
   if (typeof window === 'undefined') return null;
   try {
-    const saved = localStorage.getItem('hivemind-delegation');
+    const saved = localStorage.getItem(getDelegationStorageKey(mode));
     if (saved) {
       const parsed = JSON.parse(saved);
       if (!parsed.payments) parsed.payments = [];
       if (!parsed.approveTxHash) parsed.approveTxHash = '';
+      if (!parsed.networkMode) parsed.networkMode = mode;
       return parsed;
     }
   } catch {}
   return null;
 }
 
-export function recordDelegationSpend(amount: number, specialist?: string, txHash?: string) {
-  const state = getDelegationState();
+export function recordDelegationSpend(mode: NetworkMode, amount: number, specialist?: string, txHash?: string) {
+  const state = getDelegationState(mode);
   if (!state) return;
   
   state.payments.push({
@@ -62,19 +68,24 @@ export function recordDelegationSpend(amount: number, specialist?: string, txHas
   if (state.spent >= state.allowance) {
     state.enabled = false;
   }
-  localStorage.setItem('hivemind-delegation', JSON.stringify(state));
+  localStorage.setItem(getDelegationStorageKey(mode), JSON.stringify(state));
   window.dispatchEvent(new Event('delegation-updated'));
 }
 
-export function getDelegationTotalSpent(): number {
-  const state = getDelegationState();
+export function getDelegationTotalSpent(mode: NetworkMode): number {
+  const state = getDelegationState(mode);
   if (!state) return 0;
   return state.spent;
 }
 
-export function DelegationPanel() {
+interface DelegationPanelProps {
+  networkMode: NetworkMode;
+}
+
+export function DelegationPanel({ networkMode }: DelegationPanelProps) {
   const { address, isConnected } = useAccount();
-  const { writeContractAsync, isPending: isWritePending } = useWriteContract();
+  const { writeContractAsync } = useWriteContract();
+  const network = getNetworkConfig(networkMode);
   const [delegation, setDelegation] = useState<DelegationState | null>(null);
   const [approveAmount, setApproveAmount] = useState(5);
   const [isApproving, setIsApproving] = useState(false);
@@ -82,14 +93,14 @@ export function DelegationPanel() {
   const [txError, setTxError] = useState<string | null>(null);
 
   useEffect(() => {
-    setDelegation(getDelegationState());
-  }, []);
+    setDelegation(getDelegationState(networkMode));
+  }, [networkMode]);
 
   useEffect(() => {
-    const handler = () => setDelegation(getDelegationState());
+    const handler = () => setDelegation(getDelegationState(networkMode));
     window.addEventListener('delegation-updated', handler);
     return () => window.removeEventListener('delegation-updated', handler);
-  }, []);
+  }, [networkMode]);
 
   if (!isConnected) return null;
 
@@ -105,15 +116,19 @@ export function DelegationPanel() {
       // On-chain: approve the delegate address to spend user's USDC
       const amountWei = parseUnits(String(approveAmount), 6);
       const txHash = await writeContractAsync({
-        address: USDC_ADDRESS,
+        address: network.usdcAddress,
         abi: USDC_APPROVE_ABI,
         functionName: 'approve',
-        args: [DELEGATE_ADDRESS, amountWei],
-        chainId: baseSepolia.id,
+        args: [network.delegateAddress, amountWei],
+        chainId: network.chainId,
       });
 
       // Persist delegation state
       const newState: DelegationState = {
+        networkMode,
+        chainId: network.chainId,
+        delegateAddress: network.delegateAddress,
+        usdcAddress: network.usdcAddress,
         enabled: true,
         allowance: approveAmount,
         spent: 0,
@@ -121,7 +136,7 @@ export function DelegationPanel() {
         approveTxHash: txHash,
         payments: [],
       };
-      localStorage.setItem('hivemind-delegation', JSON.stringify(newState));
+      localStorage.setItem(getDelegationStorageKey(networkMode), JSON.stringify(newState));
       setDelegation(newState);
       window.dispatchEvent(new Event('delegation-updated'));
     } catch (err: any) {
@@ -140,15 +155,15 @@ export function DelegationPanel() {
     try {
       // On-chain: set approval to 0
       await writeContractAsync({
-        address: USDC_ADDRESS,
+        address: network.usdcAddress,
         abi: USDC_APPROVE_ABI,
         functionName: 'approve',
-        args: [DELEGATE_ADDRESS, BigInt(0)],
-        chainId: baseSepolia.id,
+        args: [network.delegateAddress, BigInt(0)],
+        chainId: network.chainId,
       });
 
       // Clear local state
-      localStorage.removeItem('hivemind-delegation');
+      localStorage.removeItem(getDelegationStorageKey(networkMode));
       setDelegation(null);
       window.dispatchEvent(new Event('delegation-updated'));
     } catch (err: any) {
@@ -199,7 +214,7 @@ export function DelegationPanel() {
           {/* Approval tx link */}
           {delegation.approveTxHash && (
             <a
-              href={`https://sepolia.basescan.org/tx/${delegation.approveTxHash}`}
+              href={getExplorerTxUrl(networkMode, delegation.approveTxHash)}
               target="_blank"
               rel="noopener noreferrer"
               className="text-[10px] text-cyan-400/60 hover:text-cyan-400 transition-colors font-mono truncate block"
@@ -235,7 +250,7 @@ export function DelegationPanel() {
       ) : (
         <div className="space-y-2">
           <p className="text-[10px] text-[var(--text-muted)]">
-            Approve a USDC spending limit on-chain. Agent fees auto-deduct — no popup each time.
+            Approve a USDC spending limit on {network.chainName}. Agent fees auto-deduct and stay isolated to this environment.
           </p>
           <div className="flex items-center gap-2">
             <input

--- a/frontend/src/components/PaymentFeed.tsx
+++ b/frontend/src/components/PaymentFeed.tsx
@@ -6,7 +6,7 @@ import { CreditCard, ExternalLink, ArrowRight, Coins, RefreshCw } from 'lucide-r
 import type { Payment } from '@/types';
 import { getDelegationTotalSpent } from '@/components/DelegationPanel';
 import type { NetworkMode } from '@/types';
-import { NETWORK_MODE_LABELS, getExplorerTxUrl } from '@/lib/networkMode';
+import { getModeScopedStorageKey, NETWORK_MODE_LABELS, getExplorerTxUrl } from '@/lib/networkMode';
 
 interface PaymentFeedProps {
   payments: Payment[];
@@ -156,24 +156,26 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
   const [userPayments, setUserPayments] = useState<Payment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [delegationSpent, setDelegationSpent] = useState(0);
+  const userPaymentsStorageKey = getModeScopedStorageKey('hivemind-user-payments', networkMode);
 
   // Re-read delegation total when it updates
   useEffect(() => {
-    setDelegationSpent(getDelegationTotalSpent());
-    const handler = () => setDelegationSpent(getDelegationTotalSpent());
+    setDelegationSpent(getDelegationTotalSpent(networkMode));
+    const handler = () => setDelegationSpent(getDelegationTotalSpent(networkMode));
     window.addEventListener('delegation-updated', handler);
     return () => window.removeEventListener('delegation-updated', handler);
-  }, []);
+  }, [networkMode]);
 
   // Listen for user wallet payments (real on-chain txs)
   useEffect(() => {
     const handler = (e: Event) => {
       const payment = (e as CustomEvent).detail as Payment;
+      if ((payment.networkMode || networkMode) !== networkMode) return;
       setUserPayments(prev => {
         const updated = [payment, ...prev];
         // Persist to localStorage
         try {
-          localStorage.setItem('hivemind-user-payments', JSON.stringify(updated.map(p => ({
+          localStorage.setItem(userPaymentsStorageKey, JSON.stringify(updated.map(p => ({
             ...p,
             timestamp: typeof p.timestamp === 'string' ? p.timestamp : String(p.timestamp),
           }))));
@@ -183,28 +185,30 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
     };
     window.addEventListener('hivemind-payment', handler);
     return () => window.removeEventListener('hivemind-payment', handler);
-  }, []);
+  }, [networkMode, userPaymentsStorageKey]);
 
   // Load persisted user payments on mount
   useEffect(() => {
     try {
-      const saved = localStorage.getItem('hivemind-user-payments');
+      const saved = localStorage.getItem(userPaymentsStorageKey);
       if (saved) {
         const parsed = JSON.parse(saved).map((p: any) => ({
           ...p,
           timestamp: new Date(p.timestamp),
         }));
         setUserPayments(parsed);
+      } else {
+        setUserPayments([]);
       }
     } catch {}
-  }, []);
+  }, [userPaymentsStorageKey]);
 
   // Fetch persisted payment history from backend
   useEffect(() => {
     const fetchHistory = async () => {
       try {
         const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-        const res = await fetch(`${apiUrl}/wallet/transactions`);
+        const res = await fetch(`${apiUrl}/wallet/transactions?network=${networkMode}`);
         if (res.ok) {
           const data = await res.json();
           if (data.transactions?.length > 0) {
@@ -228,6 +232,8 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
               method: tx.method || (tx.txHash && !tx.txHash.startsWith('0x') ? 'x402' : 'on-chain'),
             }));
             setHistoricPayments(mapped);
+          } else {
+            setHistoricPayments([]);
           }
         }
       } catch (err) {
@@ -236,7 +242,7 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
       setIsLoading(false);
     };
     fetchHistory();
-  }, []);
+  }, [networkMode]);
 
   // Merge user payments + historic, dedup by txSignature
   // User payments (real on-chain) take priority over dispatcher fake payments
@@ -255,6 +261,7 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
     }
     // Realtime from dispatcher (skip fake tracking IDs)
     for (const p of realtimePayments) {
+      if ((p.networkMode || networkMode) !== networkMode) continue;
       if (p.txSignature?.startsWith('user-pay-')) continue; // Skip fake payments
       const key = p.txSignature || p.id || `rt-${merged.length}`;
       if (!seen.has(key)) {
@@ -321,7 +328,7 @@ export function PaymentFeed({ payments: realtimePayments, className = '', networ
               onClick={() => {
                 setUserPayments([]);
                 setHistoricPayments([]);
-                localStorage.removeItem('hivemind-user-payments');
+                localStorage.removeItem(userPaymentsStorageKey);
               }}
               className="text-[10px] text-[var(--text-muted)] hover:text-red-400 transition-colors"
               title="Clear payment history"

--- a/frontend/src/components/PaymentFlow.tsx
+++ b/frontend/src/components/PaymentFlow.tsx
@@ -2,15 +2,10 @@
 import { useState } from 'react';
 import { Transaction, TransactionButton, TransactionStatus } from '@coinbase/onchainkit/transaction';
 import { useAccount } from 'wagmi';
-import { baseSepolia } from 'wagmi/chains';
 import type { NetworkMode } from '@/types';
-import { NETWORK_MODE_LABELS, supportsDirectPayments } from '@/lib/networkMode';
+import { getNetworkConfig, NETWORK_MODE_LABELS, supportsDirectPayments } from '@/lib/networkMode';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, HelpCircle } from 'lucide-react';
-
-// USDC contract on Base Sepolia
-const USDC_ADDRESS = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
-const TREASURY_ADDRESS = '0x676fF3d546932dE6558a267887E58e39f405B135';
 
 interface PaymentFlowProps {
   specialistId: string;
@@ -23,8 +18,9 @@ interface PaymentFlowProps {
 
 export function PaymentFlow({ specialistId, fee, onPaymentComplete, onCancel, recipientAddress, networkMode = 'testnet' }: PaymentFlowProps) {
   const { address, isConnected } = useAccount();
+  const network = getNetworkConfig(networkMode);
   
-  const recipient = recipientAddress || TREASURY_ADDRESS;
+  const recipient = recipientAddress || network.treasuryAddress;
   const [showExplainer, setShowExplainer] = useState(false);
   
   if (!isConnected) {
@@ -46,7 +42,7 @@ export function PaymentFlow({ specialistId, fee, onPaymentComplete, onCancel, re
 
   // ERC-20 transfer call
   const calls = [{
-    to: USDC_ADDRESS as `0x${string}`,
+    to: network.usdcAddress,
     data: encodeTransferCall(recipient, fee),
   }];
 
@@ -122,7 +118,7 @@ export function PaymentFlow({ specialistId, fee, onPaymentComplete, onCancel, re
               className="overflow-hidden mb-4"
             >
               <div className="p-3 rounded-lg bg-white/5 text-xs text-[var(--text-secondary)] space-y-2">
-                <p>🔐 <strong>x402 Protocol:</strong> Your payment is sent as USDC on Base Sepolia directly to the specialist agent.</p>
+                <p>🔐 <strong>x402 Protocol:</strong> Your payment is sent as USDC on {network.chainName} directly to the specialist agent.</p>
                 <p>⚡ <strong>Instant Settlement:</strong> The agent verifies payment on-chain before responding — no middleman.</p>
                 <p>🧾 <strong>Transparent Pricing:</strong> Each specialist sets their own price based on compute cost and data quality.</p>
               </div>
@@ -132,7 +128,7 @@ export function PaymentFlow({ specialistId, fee, onPaymentComplete, onCancel, re
         
         <div className="space-y-4">
           <Transaction
-            chainId={baseSepolia.id}
+            chainId={network.chainId}
             calls={calls}
             onSuccess={(response) => {
               if (response.transactionReceipts[0]) {

--- a/frontend/src/components/TransactionApproval.tsx
+++ b/frontend/src/components/TransactionApproval.tsx
@@ -3,7 +3,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, CheckCircle, AlertCircle, ArrowRightLeft, Send, Wallet, Info } from 'lucide-react';
 import { useAccount, useBalance } from 'wagmi';
-import { baseSepolia } from 'wagmi/chains';
+import { getNetworkConfig, type NetworkMode } from '@/lib/networkMode';
 
 export interface TransactionDetails {
   type: 'swap' | 'transfer';
@@ -17,13 +17,12 @@ export interface TransactionDetails {
   currentBalance?: string;
 }
 
-const USDC_ADDRESS = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' as `0x${string}`;
-
 interface TransactionApprovalProps {
   isOpen: boolean;
   details: TransactionDetails | null;
   onApprove: () => void;
   onReject: () => void;
+  networkMode: NetworkMode;
 }
 
 export function TransactionApproval({
@@ -31,18 +30,20 @@ export function TransactionApproval({
   details,
   onApprove,
   onReject,
+  networkMode,
 }: TransactionApprovalProps) {
+  const network = getNetworkConfig(networkMode);
   // Get connected wallet balance
   const { address: onchainAddress, isConnected: isOnchainConnected } = useAccount();
   const { data: usdcBalance } = useBalance({
     address: onchainAddress,
-    token: USDC_ADDRESS,
-    chainId: baseSepolia.id,
+    token: network.usdcAddress,
+    chainId: network.chainId,
     query: { enabled: isOnchainConnected },
   });
   const { data: ethBalance } = useBalance({
     address: onchainAddress,
-    chainId: baseSepolia.id,
+    chainId: network.chainId,
     query: { enabled: isOnchainConnected },
   });
 
@@ -161,7 +162,7 @@ export function TransactionApproval({
                       <span className="text-gray-400 text-xs flex items-center gap-1">
                         <Info className="w-3 h-3" /> Network
                       </span>
-                      <span className="text-gray-300 text-xs">Base Sepolia</span>
+                      <span className="text-gray-300 text-xs">{network.chainName}</span>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/components/WalletPanel.tsx
+++ b/frontend/src/components/WalletPanel.tsx
@@ -2,12 +2,14 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Wallet, Copy, Check, ExternalLink, RefreshCw, ChevronDown, ChevronUp, User, Zap } from 'lucide-react';
+import { Wallet, Copy, Check, ExternalLink, RefreshCw, User, Zap } from 'lucide-react';
 import { useAccount, useBalance } from 'wagmi';
-import { baseSepolia } from 'wagmi/chains';
+import { getExplorerAddressUrl, getNetworkConfig, type NetworkMode } from '@/lib/networkMode';
+import { getDelegationState } from './DelegationPanel';
 
 interface WalletPanelProps {
   className?: string;
+  networkMode: NetworkMode;
 }
 
 interface TokenBalance {
@@ -17,25 +19,23 @@ interface TokenBalance {
   color: string;
 }
 
-const TREASURY_ADDRESS = '0x676fF3d546932dE6558a267887E58e39f405B135';
-const USDC_ADDRESS = '0x036CbD53842c5426634e7929541eC2318f3dCF7e' as `0x${string}`;
-
 const TOKEN_CONFIG: Record<string, { icon: string; color: string; decimals: number }> = {
   ETH: { icon: 'Ξ', color: 'from-[#627EEA] to-[#627EEA]', decimals: 4 },
   USDC: { icon: '$', color: 'from-[#2775CA] to-[#2775CA]', decimals: 4 },
 };
 
-export function WalletPanel({ className = '' }: WalletPanelProps) {
-  const { address, isConnected } = useAccount();
+export function WalletPanel({ className = '', networkMode }: WalletPanelProps) {
+  const network = getNetworkConfig(networkMode);
+  const { address, isConnected, chainId } = useAccount();
   const { data: ethBalance, refetch: refetchEth } = useBalance({
     address,
-    chainId: baseSepolia.id,
+    chainId: network.chainId,
     query: { enabled: isConnected },
   });
   const { data: usdcBalance, refetch: refetchUsdc } = useBalance({
     address,
-    token: USDC_ADDRESS,
-    chainId: baseSepolia.id,
+    token: network.usdcAddress,
+    chainId: network.chainId,
     query: { enabled: isConnected },
   });
 
@@ -46,8 +46,9 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
   const [copied, setCopied] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const delegation = getDelegationState(networkMode);
 
-  const displayAddress = isConnected ? (address || '') : TREASURY_ADDRESS;
+  const displayAddress = isConnected ? (address || '') : network.treasuryAddress;
 
   const truncateAddress = (addr: string) => `${addr.slice(0, 6)}...${addr.slice(-4)}`;
 
@@ -58,7 +59,7 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
   };
 
   const openBasescan = () => {
-    window.open(`https://sepolia.basescan.org/address/${displayAddress}`, '_blank');
+    window.open(getExplorerAddressUrl(networkMode, displayAddress), '_blank');
   };
 
   const formatBalance = (symbol: string, amount: number): string => {
@@ -92,7 +93,7 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
     // Fallback: fetch treasury balance from backend API
     try {
       const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-      const res = await fetch(`${apiUrl}/api/wallet/balances`);
+      const res = await fetch(`${apiUrl}/api/wallet/balances?network=${networkMode}`);
       if (res.ok) {
         const data = await res.json();
         const base = data.base || data.balances || {};
@@ -106,13 +107,19 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
       console.error('Failed to fetch balance:', error);
     }
     setIsRefreshing(false);
-  }, [isConnected, refetchEth, refetchUsdc]);
+  }, [isConnected, networkMode, refetchEth, refetchUsdc]);
 
   useEffect(() => {
     fetchBalance();
     const interval = setInterval(fetchBalance, 15000);
     return () => clearInterval(interval);
   }, [fetchBalance]);
+
+  const delegationRemaining = delegation ? Math.max(0, delegation.allowance - delegation.spent) : 0;
+  const delegationPercent = delegation && delegation.allowance > 0
+    ? Math.max(0, Math.min(100, (delegationRemaining / delegation.allowance) * 100))
+    : 0;
+  const hasChainMismatch = Boolean(isConnected && chainId && chainId !== network.chainId);
 
   return (
     <div className={`glass-panel overflow-hidden ${className}`}>
@@ -126,6 +133,11 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
           {isConnected && (
             <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-green-500/20 text-green-400 font-medium">
               Connected
+            </span>
+          )}
+          {hasChainMismatch && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/20 text-amber-300 font-medium">
+              Wrong Network
             </span>
           )}
         </div>
@@ -218,26 +230,26 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
         </div>
 
         {/* Delegation remaining display */}
-        <div className="mt-4 p-3 rounded-lg bg-white/5 border border-white/10">
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-2">
-              <Zap size={14} className="text-[var(--accent-purple)]" />
-              <span className="text-xs text-[var(--text-muted)]">Delegation Remaining</span>
-            </div>
-            {/* Hardcoded delegation amount for now */}
+          <div className="mt-4 p-3 rounded-lg bg-white/5 border border-white/10">
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                <Zap size={14} className="text-[var(--accent-purple)]" />
+                <span className="text-xs text-[var(--text-muted)]">Delegation Remaining</span>
+              </div>
             <span className="text-xs font-semibold text-[var(--text-primary)]">
-              $25.00 USDC
-              {/* Add warning badge if delegation < $1 */}
-              {25.00 < 1.0 && (
+              ${delegationRemaining.toFixed(2)} USDC
+              {delegation && delegationRemaining < 1.0 && (
                 <span className="ml-2 px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 text-[10px] font-medium">
                   Low Delegation
                 </span>
               )}
             </span>
-          </div>
-          {/* Simple progress bar, hardcoded 80% for now */}
+            </div>
           <div className="w-full h-2 bg-white/10 rounded-full overflow-hidden">
-            <div className="h-full bg-[var(--accent-purple)] rounded-full" style={{ width: '80%' }}></div>
+            <div className="h-full bg-[var(--accent-purple)] rounded-full" style={{ width: `${delegationPercent}%` }}></div>
+          </div>
+          <div className="mt-2 text-[10px] text-[var(--text-muted)]">
+            {delegation ? `${delegation.spent.toFixed(2)} spent of ${delegation.allowance.toFixed(2)} approved on ${network.chainName}` : `No delegation approved on ${network.chainName}`}
           </div>
         </div>
 
@@ -268,7 +280,7 @@ export function WalletPanel({ className = '' }: WalletPanelProps) {
           </motion.button>
           <div className="flex items-center gap-1 text-[10px] text-[var(--text-muted)]">
             <div className="w-1.5 h-1.5 rounded-full bg-blue-500" />
-            <span>Base Sepolia</span>
+            <span>{network.chainName}</span>
           </div>
         </div>
 

--- a/frontend/src/lib/networkMode.ts
+++ b/frontend/src/lib/networkMode.ts
@@ -1,37 +1,117 @@
+import { base, baseSepolia } from 'wagmi/chains';
+
 export type NetworkMode = 'testnet' | 'mainnet';
 
 export const NETWORK_MODE_STORAGE_KEY = 'hivemind-network-mode';
+export const NETWORK_MODE_EVENT = 'hivemind-network-mode-change';
 
-export const NETWORK_MODE_LABELS: Record<NetworkMode, { label: string; shortLabel: string; badge: string; explorerBase: string }> = {
+export interface FrontendNetworkConfig {
+  mode: NetworkMode;
+  chain: typeof base | typeof baseSepolia;
+  chainId: number;
+  chainName: string;
+  label: string;
+  shortLabel: string;
+  badge: string;
+  routeLabel: 'base-mainnet' | 'base-sepolia';
+  eip155: `eip155:${number}`;
+  explorerBase: string;
+  usdcAddress: `0x${string}`;
+  treasuryAddress: `0x${string}`;
+  delegateAddress: `0x${string}`;
+  identityRegistry?: string;
+  reputationRegistry?: string;
+}
+
+const NETWORKS: Record<NetworkMode, FrontendNetworkConfig> = {
   testnet: {
+    mode: 'testnet',
+    chain: baseSepolia,
+    chainId: 84532,
+    chainName: 'Base Sepolia',
     label: 'Base Sepolia (Testnet)',
     shortLabel: 'Testnet',
     badge: 'TESTNET',
+    routeLabel: 'base-sepolia',
+    eip155: 'eip155:84532',
     explorerBase: 'https://sepolia.basescan.org',
+    usdcAddress: (process.env.NEXT_PUBLIC_BASE_TESTNET_USDC_ADDRESS || process.env.NEXT_PUBLIC_BASE_USDC_ADDRESS || '0x036CbD53842c5426634e7929541eC2318f3dCF7e') as `0x${string}`,
+    treasuryAddress: (process.env.NEXT_PUBLIC_TREASURY_WALLET_EVM_TESTNET || process.env.NEXT_PUBLIC_TREASURY_WALLET_EVM || '0x676fF3d546932dE6558a267887E58e39f405B135') as `0x${string}`,
+    delegateAddress: (process.env.NEXT_PUBLIC_DELEGATE_WALLET_EVM_TESTNET || process.env.NEXT_PUBLIC_DELEGATE_WALLET_EVM || '0x4a9948159B7e6c19301ebc388E72B1EdFf87187B') as `0x${string}`,
+    identityRegistry: process.env.NEXT_PUBLIC_ERC8004_TESTNET_IDENTITY_REGISTRY || process.env.NEXT_PUBLIC_ERC8004_IDENTITY_REGISTRY,
+    reputationRegistry: process.env.NEXT_PUBLIC_ERC8004_TESTNET_REPUTATION_REGISTRY || process.env.NEXT_PUBLIC_ERC8004_REPUTATION_REGISTRY,
   },
   mainnet: {
+    mode: 'mainnet',
+    chain: base,
+    chainId: 8453,
+    chainName: 'Base Mainnet',
     label: 'Base Mainnet',
     shortLabel: 'Mainnet',
     badge: 'MAINNET',
+    routeLabel: 'base-mainnet',
+    eip155: 'eip155:8453',
     explorerBase: 'https://basescan.org',
+    usdcAddress: (process.env.NEXT_PUBLIC_BASE_MAINNET_USDC_ADDRESS || '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913') as `0x${string}`,
+    treasuryAddress: (process.env.NEXT_PUBLIC_TREASURY_WALLET_EVM_MAINNET || process.env.NEXT_PUBLIC_TREASURY_WALLET_EVM || '0x676fF3d546932dE6558a267887E58e39f405B135') as `0x${string}`,
+    delegateAddress: (process.env.NEXT_PUBLIC_DELEGATE_WALLET_EVM_MAINNET || process.env.NEXT_PUBLIC_DELEGATE_WALLET_EVM || '0x4a9948159B7e6c19301ebc388E72B1EdFf87187B') as `0x${string}`,
+    identityRegistry: process.env.NEXT_PUBLIC_ERC8004_MAINNET_IDENTITY_REGISTRY,
+    reputationRegistry: process.env.NEXT_PUBLIC_ERC8004_MAINNET_REPUTATION_REGISTRY,
   },
 };
 
+export const NETWORK_MODE_LABELS: Record<NetworkMode, { label: string; shortLabel: string; badge: string; explorerBase: string }> = {
+  testnet: NETWORKS.testnet,
+  mainnet: NETWORKS.mainnet,
+};
+
+export function getNetworkConfig(mode: NetworkMode): FrontendNetworkConfig {
+  return NETWORKS[mode];
+}
+
 export function getExplorerTxUrl(mode: NetworkMode, txHash: string): string {
-  return `${NETWORK_MODE_LABELS[mode].explorerBase}/tx/${txHash}`;
+  return `${NETWORKS[mode].explorerBase}/tx/${txHash}`;
 }
 
 export function getExplorerAddressUrl(mode: NetworkMode, address: string): string {
-  return `${NETWORK_MODE_LABELS[mode].explorerBase}/address/${address}`;
+  return `${NETWORKS[mode].explorerBase}/address/${address}`;
 }
 
 export function resolveNetworkMode(input?: string | null): NetworkMode {
   const value = String(input || '').toLowerCase();
-  if (value.includes('8453') || value.includes('mainnet')) return 'mainnet';
+  if (
+    value === 'testnet' ||
+    value.includes('84532') ||
+    value.includes('base-sepolia') ||
+    value.includes('eip155:84532')
+  ) {
+    return 'testnet';
+  }
+  if (
+    value.includes('eip155:8453') ||
+    value.includes('mainnet') ||
+    value.includes('base-mainnet') ||
+    /(^|[^0-9])8453([^0-9]|$)/.test(value)
+  ) {
+    return 'mainnet';
+  }
   return 'testnet';
 }
 
 export function supportsDirectPayments(mode: NetworkMode): boolean {
   if (mode === 'testnet') return true;
   return process.env.NEXT_PUBLIC_ENABLE_MAINNET_PAYMENTS === 'true';
+}
+
+export function getModeScopedStorageKey(baseKey: string, mode: NetworkMode): string {
+  return `${baseKey}:${mode}`;
+}
+
+export function getStoredNetworkMode(): NetworkMode {
+  if (typeof window === 'undefined') return 'testnet';
+  return resolveNetworkMode(window.localStorage.getItem(NETWORK_MODE_STORAGE_KEY));
+}
+
+export function isChainIdForMode(mode: NetworkMode, chainId?: number): boolean {
+  return chainId === undefined ? false : NETWORKS[mode].chainId === chainId;
 }

--- a/frontend/src/providers/OnchainProviders.tsx
+++ b/frontend/src/providers/OnchainProviders.tsx
@@ -2,11 +2,13 @@
 import { OnchainKitProvider } from '@coinbase/onchainkit';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WagmiProvider, createConfig, http } from 'wagmi';
-import { baseSepolia } from 'wagmi/chains';
+import { base, baseSepolia } from 'wagmi/chains';
 import { coinbaseWallet } from 'wagmi/connectors';
+import { useEffect, useState } from 'react';
+import { getNetworkConfig, getStoredNetworkMode, NETWORK_MODE_EVENT, type NetworkMode } from '@/lib/networkMode';
 
 const config = createConfig({
-  chains: [baseSepolia],
+  chains: [baseSepolia, base],
   connectors: [
     coinbaseWallet({
       appName: 'Hivemind Protocol',
@@ -15,17 +17,37 @@ const config = createConfig({
   ],
   transports: {
     [baseSepolia.id]: http(),
+    [base.id]: http(),
   },
 });
 
 const queryClient = new QueryClient();
 
 export function OnchainProviders({ children }: { children: React.ReactNode }) {
+  const [networkMode, setNetworkMode] = useState<NetworkMode>(getStoredNetworkMode);
+  const network = getNetworkConfig(networkMode);
+
+  useEffect(() => {
+    const handleModeChange = (event?: Event) => {
+      const nextMode = (event as CustomEvent<NetworkMode> | undefined)?.detail;
+      setNetworkMode(nextMode || getStoredNetworkMode());
+    };
+
+    handleModeChange();
+    window.addEventListener(NETWORK_MODE_EVENT, handleModeChange as EventListener);
+    window.addEventListener('storage', handleModeChange as EventListener);
+    return () => {
+      window.removeEventListener(NETWORK_MODE_EVENT, handleModeChange as EventListener);
+      window.removeEventListener('storage', handleModeChange as EventListener);
+    };
+  }, []);
+
   return (
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
         <OnchainKitProvider
-          chain={baseSepolia}
+          key={networkMode}
+          chain={network.chain}
           config={{
             appearance: {
               mode: 'dark', // Match our dark theme


### PR DESCRIPTION
Implements real Hivemind environment switching for #1.

## What changed
- added shared mode-aware network config and mode normalization
- switched backend discovery/registry/dispatch/payment paths to use active mode instead of hard-coded Sepolia assumptions
- isolated external-agent state and payment behavior per network to prevent testnet/mainnet bleed-through
- updated frontend network mode/state handling so switching invalidates mode-sensitive UI state and propagates network metadata consistently
- added integration coverage for end-to-end network switching behavior

## Verification
- cd backend && npm run build
- cd backend && npm test -- --runInBand client-network.test.ts network-switching.integration.test.ts

## Notes
- Supersedes the closed scaffold PR #2.
- Frontend lint/build was not run in the ACP environment because frontend node_modules were unavailable there.